### PR TITLE
Add unsigned i8 compare lowering for MCS-51

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ The backend currently supports a narrow but working subset:
 - leaf functions operating on `i8`
 - up to two arguments passed in `R7` and `R6`
 - `i8` return values in `A`
+- unsigned `icmp` ordering comparisons lowered to `0/1` results
 - `add`, `sub`, `and`, `or`, `xor`, and integer constants
 - `llc -filetype=obj` for the supported subset
 - end-to-end verification from `C` source to machine code executed in `ucsim_51`
 
 ## Limitations
 
-- no stack frame support, spills, calls, branches, or general C ABI yet
+- no stack frame support, spills, calls, branches, equality/signed compares, or general C ABI yet
 - the end-to-end harness currently accepts only relocation-free leaf functions from the supported subset
 - the Python image packer is a small test utility, not a general-purpose 8051 linker

--- a/overlay/llvm/lib/Target/MCS51/MCS51.h
+++ b/overlay/llvm/lib/Target/MCS51/MCS51.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_LIB_TARGET_MCS51_MCS51_H
 #define LLVM_LIB_TARGET_MCS51_MCS51_H
 
+#include <cstdint>
+
 #include "MCTargetDesc/MCS51MCTargetDesc.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/SelectionDAGNodes.h"
@@ -26,9 +28,18 @@ void initializeMCS51DAGToDAGISelLegacyPass(PassRegistry &);
 namespace MCS51ISD {
 enum NodeType : unsigned {
   FIRST_NUMBER = ISD::BUILTIN_OP_END,
-  RET_FLAG
+  RET_FLAG,
+  UCMP
 };
 } // namespace MCS51ISD
+
+namespace MCS51UCmpFlags {
+enum Flags : uint8_t {
+  None = 0,
+  SwapOperands = 1u << 0,
+  InvertResult = 1u << 1,
+};
+} // namespace MCS51UCmpFlags
 
 } // namespace llvm
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
@@ -84,6 +84,30 @@ private:
       report_fatal_error("Unsupported MCS51 binary pseudo RHS");
     emitMoveAToReg(MI->getOperand(0).getReg());
   }
+
+  void emitUnsignedComparePseudo(const MachineInstr *MI) {
+    const uint8_t Flags = static_cast<uint8_t>(MI->getOperand(3).getImm());
+    const MachineOperand &LHS = MI->getOperand(1);
+    const MachineOperand &RHS = MI->getOperand(2);
+    const MachineOperand &First =
+        (Flags & MCS51UCmpFlags::SwapOperands) ? RHS : LHS;
+    const MachineOperand &Second =
+        (Flags & MCS51UCmpFlags::SwapOperands) ? LHS : RHS;
+
+    emitLoadA(First);
+    emitMCInst(MCS51::CLR_C, {});
+    if (Second.isReg())
+      emitMCInst(MCS51::SUBBA_r, {lowerPseudoOperand(Second)});
+    else if (Second.isImm())
+      emitMCInst(MCS51::SUBBA_i, {lowerPseudoOperand(Second)});
+    else
+      report_fatal_error("Unsupported MCS51 comparison RHS");
+    emitMCInst(MCS51::CLR_A, {});
+    emitMCInst(MCS51::RLC_A, {});
+    if (Flags & MCS51UCmpFlags::InvertResult)
+      emitMCInst(MCS51::XRLA_i, {MCOperand::createImm(1)});
+    emitMoveAToReg(MI->getOperand(0).getReg());
+  }
 };
 
 } // namespace
@@ -148,6 +172,14 @@ void MCS51AsmPrinter::emitInstruction(const MachineInstr *MI) {
     else
       report_fatal_error("Unsupported MCS51 subtraction RHS");
     emitMoveAToReg(MI->getOperand(0).getReg());
+    return;
+  case MCS51::UCMP8rr:
+  case MCS51::UCMP8ri:
+  case MCS51::UCMP8ir:
+  case MCS51::UCMP1rr:
+  case MCS51::UCMP1ri:
+  case MCS51::UCMP1ir:
+    emitUnsignedComparePseudo(MI);
     return;
   }
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
@@ -88,6 +88,35 @@ void MCS51DAGToDAGISel::Select(SDNode *Node) {
     return;
   }
 
+  if (Node->getOpcode() == MCS51ISD::UCMP) {
+    SDLoc DL(Node);
+    SDValue LHS = Node->getOperand(0);
+    SDValue RHS = Node->getOperand(1);
+    SDValue Flags = Node->getOperand(2);
+    EVT ResultVT = Node->getValueType(0);
+    const bool IsBoolResult = ResultVT == MVT::i1;
+    const unsigned RROpc = IsBoolResult ? MCS51::UCMP1rr : MCS51::UCMP8rr;
+    const unsigned RIOpc = IsBoolResult ? MCS51::UCMP1ri : MCS51::UCMP8ri;
+    const unsigned IROpc = IsBoolResult ? MCS51::UCMP1ir : MCS51::UCMP8ir;
+
+    if (auto *RHSImm = dyn_cast<ConstantSDNode>(RHS)) {
+      SDValue TargetImm =
+          CurDAG->getTargetConstant(RHSImm->getSExtValue(), DL, MVT::i8);
+      CurDAG->SelectNodeTo(Node, RIOpc, ResultVT, LHS, TargetImm, Flags);
+      return;
+    }
+
+    if (auto *LHSImm = dyn_cast<ConstantSDNode>(LHS)) {
+      SDValue TargetImm =
+          CurDAG->getTargetConstant(LHSImm->getSExtValue(), DL, MVT::i8);
+      CurDAG->SelectNodeTo(Node, IROpc, ResultVT, TargetImm, RHS, Flags);
+      return;
+    }
+
+    CurDAG->SelectNodeTo(Node, RROpc, ResultVT, LHS, RHS, Flags);
+    return;
+  }
+
   if (Node->getSimpleValueType(0) == MVT::i8) {
     switch (Node->getOpcode()) {
     case ISD::ADD:

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
@@ -18,10 +18,47 @@ using namespace llvm;
 
 #include "MCS51GenCallingConv.inc"
 
+namespace {
+
+uint8_t getUnsignedCompareFlags(ISD::CondCode CC) {
+  switch (CC) {
+  case ISD::SETULT:
+    return MCS51UCmpFlags::None;
+  case ISD::SETUGE:
+    return MCS51UCmpFlags::InvertResult;
+  case ISD::SETUGT:
+    return MCS51UCmpFlags::SwapOperands;
+  case ISD::SETULE:
+    return MCS51UCmpFlags::SwapOperands | MCS51UCmpFlags::InvertResult;
+  default:
+    report_fatal_error(
+        "MCS51 MVP backend supports only unsigned i8 ordering comparisons");
+  }
+}
+
+SDValue emitUnsignedCompareMaterialization(SelectionDAG &DAG, const SDLoc &DL,
+                                          EVT ResultVT, SDValue LHS,
+                                          SDValue RHS, uint8_t Flags) {
+  return DAG.getNode(MCS51ISD::UCMP, DL, ResultVT, LHS, RHS,
+                     DAG.getTargetConstant(Flags, DL, MVT::i8));
+}
+
+SDValue unwrapSetCC(SDValue Value) {
+  while (Value.getOpcode() == ISD::TRUNCATE ||
+         Value.getOpcode() == ISD::AssertZext ||
+         Value.getOpcode() == ISD::AssertSext)
+    Value = Value.getOperand(0);
+
+  return Value.getOpcode() == ISD::SETCC ? Value : SDValue();
+}
+
+} // namespace
+
 MCS51TargetLowering::MCS51TargetLowering(const TargetMachine &TM,
                                          const MCS51Subtarget &STI)
     : TargetLowering(TM) {
   addRegisterClass(MVT::i8, &MCS51::GPR8RegClass);
+  addRegisterClass(MVT::i1, &MCS51::GPR1RegClass);
 
   computeRegisterProperties(STI.getRegisterInfo());
   setStackPointerRegisterToSaveRestore(MCS51::SP);
@@ -32,6 +69,126 @@ MCS51TargetLowering::MCS51TargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::AND, MVT::i8, Legal);
   setOperationAction(ISD::OR, MVT::i8, Legal);
   setOperationAction(ISD::XOR, MVT::i8, Legal);
+  setOperationAction(ISD::SETCC, MVT::i8, Custom);
+  setOperationAction(ISD::SELECT, MVT::i8, Custom);
+  setOperationAction(ISD::SELECT_CC, MVT::i8, Custom);
+  setOperationAction(ISD::ZERO_EXTEND, MVT::i8, Custom);
+}
+
+EVT MCS51TargetLowering::getSetCCResultType(const DataLayout &DL,
+                                            LLVMContext &Context,
+                                            EVT VT) const {
+  (void)DL;
+  (void)Context;
+  (void)VT;
+  return MVT::i1;
+}
+
+SDValue MCS51TargetLowering::LowerOperation(SDValue Op,
+                                            SelectionDAG &DAG) const {
+  switch (Op.getOpcode()) {
+  case ISD::SETCC:
+    return LowerSetCC(Op, DAG);
+  case ISD::SELECT:
+    return LowerSelect(Op, DAG);
+  case ISD::SELECT_CC:
+    return LowerSelectCC(Op, DAG);
+  case ISD::ZERO_EXTEND:
+    return LowerZeroExtend(Op, DAG);
+  default:
+    llvm_unreachable("unimplemented operand");
+  }
+}
+
+SDValue MCS51TargetLowering::LowerSetCC(SDValue Op,
+                                        SelectionDAG &DAG) const {
+  if (Op.getOperand(0).getValueType() != MVT::i8 ||
+      Op.getOperand(1).getValueType() != MVT::i8)
+    report_fatal_error(
+        "MCS51 MVP backend supports only i8 ordering comparisons");
+
+  return emitUnsignedCompareMaterialization(
+      DAG, SDLoc(Op), Op.getValueType(), Op.getOperand(0), Op.getOperand(1),
+      getUnsignedCompareFlags(cast<CondCodeSDNode>(Op.getOperand(2))->get()));
+}
+
+SDValue MCS51TargetLowering::LowerSelect(SDValue Op,
+                                         SelectionDAG &DAG) const {
+  if (Op.getValueType() != MVT::i8) {
+    report_fatal_error(
+        "MCS51 MVP backend supports only i8 select materialization");
+  }
+
+  const auto *TrueC = dyn_cast<ConstantSDNode>(Op.getOperand(1));
+  const auto *FalseC = dyn_cast<ConstantSDNode>(Op.getOperand(2));
+  if (TrueC == nullptr || FalseC == nullptr)
+    report_fatal_error(
+        "MCS51 MVP backend supports only constant i8 select results");
+
+  SDValue SetCC = unwrapSetCC(Op.getOperand(0));
+  if (!SetCC || SetCC.getOperand(0).getValueType() != MVT::i8 ||
+      SetCC.getOperand(1).getValueType() != MVT::i8)
+    report_fatal_error(
+        "MCS51 MVP backend supports only selects driven by i8 setcc");
+
+  uint8_t Flags =
+      getUnsignedCompareFlags(cast<CondCodeSDNode>(SetCC.getOperand(2))->get());
+  if (TrueC->getZExtValue() == 0 && FalseC->getZExtValue() == 1)
+    Flags ^= MCS51UCmpFlags::InvertResult;
+  else if (TrueC->getZExtValue() != 1 || FalseC->getZExtValue() != 0)
+    report_fatal_error(
+        "MCS51 MVP backend supports only select materialization to 0/1");
+
+  return emitUnsignedCompareMaterialization(DAG, SDLoc(Op), Op.getValueType(),
+                                            SetCC.getOperand(0),
+                                            SetCC.getOperand(1), Flags);
+}
+
+SDValue MCS51TargetLowering::LowerSelectCC(SDValue Op,
+                                           SelectionDAG &DAG) const {
+  if (Op.getValueType() != MVT::i8 || Op.getOperand(0).getValueType() != MVT::i8 ||
+      Op.getOperand(1).getValueType() != MVT::i8)
+    report_fatal_error(
+        "MCS51 MVP backend supports only i8 select_cc materialization");
+
+  const auto *TrueC = dyn_cast<ConstantSDNode>(Op.getOperand(2));
+  const auto *FalseC = dyn_cast<ConstantSDNode>(Op.getOperand(3));
+  if (TrueC == nullptr || FalseC == nullptr)
+    report_fatal_error(
+        "MCS51 MVP backend supports only constant i8 select_cc results");
+
+  uint8_t Flags =
+      getUnsignedCompareFlags(cast<CondCodeSDNode>(Op.getOperand(4))->get());
+  if (TrueC->getZExtValue() == 0 && FalseC->getZExtValue() == 1)
+    Flags ^= MCS51UCmpFlags::InvertResult;
+  else if (TrueC->getZExtValue() != 1 || FalseC->getZExtValue() != 0)
+    report_fatal_error(
+        "MCS51 MVP backend supports only select_cc materialization to 0/1");
+
+  return emitUnsignedCompareMaterialization(DAG, SDLoc(Op), Op.getValueType(),
+                                            Op.getOperand(0),
+                                            Op.getOperand(1), Flags);
+}
+
+SDValue MCS51TargetLowering::LowerZeroExtend(SDValue Op,
+                                             SelectionDAG &DAG) const {
+  if (Op.getValueType() != MVT::i8)
+    report_fatal_error(
+        "MCS51 MVP backend supports only i8 boolean materialization");
+
+  SDValue SetCC = unwrapSetCC(Op.getOperand(0));
+  if (Op.getOperand(0).getValueType() != MVT::i1 || !SetCC)
+    report_fatal_error(
+        "MCS51 MVP backend supports only zext(setcc) boolean materialization");
+  if (SetCC.getOperand(0).getValueType() != MVT::i8 ||
+      SetCC.getOperand(1).getValueType() != MVT::i8)
+    report_fatal_error(
+        "MCS51 MVP backend supports only i8 ordering comparisons");
+
+  return emitUnsignedCompareMaterialization(
+      DAG, SDLoc(Op), Op.getValueType(), SetCC.getOperand(0),
+      SetCC.getOperand(1),
+      getUnsignedCompareFlags(cast<CondCodeSDNode>(SetCC.getOperand(2))->get()));
 }
 
 bool MCS51TargetLowering::CanLowerReturn(

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.h
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.h
@@ -19,6 +19,11 @@ class MCS51TargetLowering : public TargetLowering {
 public:
   MCS51TargetLowering(const TargetMachine &TM, const MCS51Subtarget &STI);
 
+  EVT getSetCCResultType(const DataLayout &DL, LLVMContext &Context,
+                         EVT VT) const override;
+
+  SDValue LowerOperation(SDValue Op, SelectionDAG &DAG) const override;
+
   bool CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
                       bool IsVarArg,
                       const SmallVectorImpl<ISD::OutputArg> &Outs,
@@ -34,6 +39,12 @@ public:
                       const SmallVectorImpl<ISD::OutputArg> &Outs,
                       const SmallVectorImpl<SDValue> &OutVals,
                       const SDLoc &DL, SelectionDAG &DAG) const override;
+
+private:
+  SDValue LowerSetCC(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerSelect(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerSelectCC(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerZeroExtend(SDValue Op, SelectionDAG &DAG) const;
 };
 
 } // namespace llvm

--- a/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
+++ b/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
@@ -57,6 +57,19 @@ def SUB8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
 def SUB8ri : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, i8imm:$rhs), "",
                          [(set GPR8:$dst, (sub GPR8:$lhs, imm:$rhs))]>;
 
+def UCMP8rr : MCS51Pseudo<(outs GPR8:$dst),
+                          (ins GPR8:$lhs, GPR8:$rhs, i8imm:$flags)>;
+def UCMP8ri : MCS51Pseudo<(outs GPR8:$dst),
+                          (ins GPR8:$lhs, i8imm:$rhs, i8imm:$flags)>;
+def UCMP8ir : MCS51Pseudo<(outs GPR8:$dst),
+                          (ins i8imm:$lhs, GPR8:$rhs, i8imm:$flags)>;
+def UCMP1rr : MCS51Pseudo<(outs GPR1:$dst),
+                          (ins GPR8:$lhs, GPR8:$rhs, i8imm:$flags)>;
+def UCMP1ri : MCS51Pseudo<(outs GPR1:$dst),
+                          (ins GPR8:$lhs, i8imm:$rhs, i8imm:$flags)>;
+def UCMP1ir : MCS51Pseudo<(outs GPR1:$dst),
+                          (ins i8imm:$lhs, GPR8:$rhs, i8imm:$flags)>;
+
 let Defs = [A], isAsCheapAsAMove = 1 in {
   def MOVA_r : MCS51Inst<"mov a, $src", (outs), (ins GPR8:$src)>;
   def MOVA_i : MCS51Inst<"mov a, $src", (outs), (ins i8imm:$src)> {
@@ -64,6 +77,9 @@ let Defs = [A], isAsCheapAsAMove = 1 in {
   }
   def CLR_A  : MCS51Inst<"clr a", (outs), (ins)>;
 }
+
+let Defs = [A, PSW], Uses = [A, PSW] in
+  def RLC_A : MCS51Inst<"rlc a", (outs), (ins)>;
 
 let Uses = [A], isAsCheapAsAMove = 1 in
   def MOVR_a : MCS51Inst<"mov $dst, a", (outs GPR8:$dst), (ins)>;

--- a/overlay/llvm/lib/Target/MCS51/MCS51RegisterInfo.td
+++ b/overlay/llvm/lib/Target/MCS51/MCS51RegisterInfo.td
@@ -29,6 +29,7 @@ def SP  : MCS51Reg<11, "sp">;
 def PC  : MCS51Reg<12, "pc">;
 
 def GPR8 : RegisterClass<"MCS51", [i8], 8, (add R7, R6, R5, R4, R3, R2, R1, R0)>;
+def GPR1 : RegisterClass<"MCS51", [i1], 8, (add R7, R6, R5, R4, R3, R2, R1, R0)>;
 def ACC8 : RegisterClass<"MCS51", [i8], 8, (add A)> {
   let CopyCost = -1;
 }

--- a/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
@@ -120,6 +120,9 @@ void MCS51MCCodeEmitter::encodeInstruction(const MCInst &MI,
   case MCS51::CLR_A:
     emitByte(CB, 0xE4);
     return;
+  case MCS51::RLC_A:
+    emitByte(CB, 0x33);
+    return;
   case MCS51::MOVR_a:
     emitByte(CB, static_cast<uint8_t>(0xF8u + getRegNum(MI, 0)));
     return;

--- a/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
@@ -117,3 +117,39 @@ entry:
 ; CHECK: mov r7, a
 ; CHECK: mov a, r7
 ; CHECK: ret
+
+define i8 @uge_u8(i8 %a, i8 %b) {
+entry:
+  %cmp = icmp uge i8 %a, %b
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: uge_u8:
+; CHECK: mov a, r7
+; CHECK: clr c
+; CHECK: subb a, r6
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: xrl a, #1
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @ule_u8(i8 %a, i8 %b) {
+entry:
+  %cmp = icmp ule i8 %a, %b
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: ule_u8:
+; CHECK: mov a, r6
+; CHECK: clr c
+; CHECK: subb a, r7
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: xrl a, #1
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret

--- a/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
@@ -49,3 +49,71 @@ entry:
 ; CHECK: mov r7, a
 ; CHECK: mov a, r7
 ; CHECK: ret
+
+define i8 @ult_u8(i8 %a, i8 %b) {
+entry:
+  %cmp = icmp ult i8 %a, %b
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: ult_u8:
+; CHECK: mov a, r7
+; CHECK: clr c
+; CHECK: subb a, r6
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @ugt_u8(i8 %a, i8 %b) {
+entry:
+  %cmp = icmp ugt i8 %a, %b
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: ugt_u8:
+; CHECK: mov a, r6
+; CHECK: clr c
+; CHECK: subb a, r7
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @uge_imm_u8(i8 %a) {
+entry:
+  %cmp = icmp uge i8 %a, 5
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: uge_imm_u8:
+; CHECK: mov a, #4
+; CHECK: clr c
+; CHECK: subb a, r7
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @ule_imm_u8(i8 %a) {
+entry:
+  %cmp = icmp ule i8 %a, 5
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: ule_imm_u8:
+; CHECK: mov a, r7
+; CHECK: clr c
+; CHECK: subb a, #6
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret

--- a/tests/e2e/cases.json
+++ b/tests/e2e/cases.json
@@ -54,5 +54,19 @@
     "function": "ule_imm_u8",
     "args": [6],
     "expected": 0
+  },
+  {
+    "name": "uge_u8",
+    "file": "uge_u8.c",
+    "function": "uge_u8",
+    "args": [7, 7],
+    "expected": 1
+  },
+  {
+    "name": "ule_u8",
+    "file": "ule_u8.c",
+    "function": "ule_u8",
+    "args": [8, 7],
+    "expected": 0
   }
 ]

--- a/tests/e2e/cases.json
+++ b/tests/e2e/cases.json
@@ -31,42 +31,42 @@
     "name": "ult_u8",
     "file": "ult_u8.c",
     "function": "ult_u8",
-    "args": [3, 7],
+    "args": [7, 200],
     "expected": 1
   },
   {
     "name": "ugt_u8",
     "file": "ugt_u8.c",
     "function": "ugt_u8",
-    "args": [3, 7],
-    "expected": 0
+    "args": [200, 7],
+    "expected": 1
   },
   {
     "name": "uge_imm_u8",
     "file": "uge_imm_u8.c",
     "function": "uge_imm_u8",
-    "args": [5],
+    "args": [250],
     "expected": 1
   },
   {
     "name": "ule_imm_u8",
     "file": "ule_imm_u8.c",
     "function": "ule_imm_u8",
-    "args": [6],
+    "args": [250],
     "expected": 0
   },
   {
     "name": "uge_u8",
     "file": "uge_u8.c",
     "function": "uge_u8",
-    "args": [7, 7],
+    "args": [200, 7],
     "expected": 1
   },
   {
     "name": "ule_u8",
     "file": "ule_u8.c",
     "function": "ule_u8",
-    "args": [8, 7],
-    "expected": 0
+    "args": [7, 200],
+    "expected": 1
   }
 ]

--- a/tests/e2e/cases.json
+++ b/tests/e2e/cases.json
@@ -26,5 +26,33 @@
     "function": "const_42",
     "args": [],
     "expected": 42
+  },
+  {
+    "name": "ult_u8",
+    "file": "ult_u8.c",
+    "function": "ult_u8",
+    "args": [3, 7],
+    "expected": 1
+  },
+  {
+    "name": "ugt_u8",
+    "file": "ugt_u8.c",
+    "function": "ugt_u8",
+    "args": [3, 7],
+    "expected": 0
+  },
+  {
+    "name": "uge_imm_u8",
+    "file": "uge_imm_u8.c",
+    "function": "uge_imm_u8",
+    "args": [5],
+    "expected": 1
+  },
+  {
+    "name": "ule_imm_u8",
+    "file": "ule_imm_u8.c",
+    "function": "ule_imm_u8",
+    "args": [6],
+    "expected": 0
   }
 ]

--- a/tests/e2e/uge_imm_u8.c
+++ b/tests/e2e/uge_imm_u8.c
@@ -1,0 +1,3 @@
+unsigned char uge_imm_u8(unsigned char a) {
+  return a >= 5;
+}

--- a/tests/e2e/uge_u8.c
+++ b/tests/e2e/uge_u8.c
@@ -1,0 +1,3 @@
+unsigned char uge_u8(unsigned char a, unsigned char b) {
+  return a >= b;
+}

--- a/tests/e2e/ugt_u8.c
+++ b/tests/e2e/ugt_u8.c
@@ -1,0 +1,3 @@
+unsigned char ugt_u8(unsigned char a, unsigned char b) {
+  return a > b;
+}

--- a/tests/e2e/ule_imm_u8.c
+++ b/tests/e2e/ule_imm_u8.c
@@ -1,0 +1,3 @@
+unsigned char ule_imm_u8(unsigned char a) {
+  return a <= 5;
+}

--- a/tests/e2e/ule_u8.c
+++ b/tests/e2e/ule_u8.c
@@ -1,0 +1,3 @@
+unsigned char ule_u8(unsigned char a, unsigned char b) {
+  return a <= b;
+}

--- a/tests/e2e/ult_u8.c
+++ b/tests/e2e/ult_u8.c
@@ -1,0 +1,3 @@
+unsigned char ult_u8(unsigned char a, unsigned char b) {
+  return a < b;
+}


### PR DESCRIPTION
## Summary
- add lowering and pseudo-instruction expansion for unsigned `i8` ordering comparisons
- add LLVM codegen regression coverage for `<`, `>`, `>=`, and `<=`
- add end-to-end C tests and document the new supported subset

## Validation
- GitHub Actions `test` check
