### PR TITLE
Add eq/ne compare materialization for MCS-51

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ The backend currently supports a narrow but working subset:
 - leaf functions operating on `i8`
 - up to two arguments passed in `R7` and `R6`
 - `i8` return values in `A`
-- unsigned `icmp` ordering comparisons lowered to `0/1` results
+- `icmp eq/ne` and unsigned ordering comparisons lowered to `0/1` results
 - `add`, `sub`, `and`, `or`, `xor`, and integer constants
 - `llc -filetype=obj` for the supported subset
 - end-to-end verification from `C` source to machine code executed in `ucsim_51`
 
 ## Limitations
 
-- no stack frame support, spills, calls, branches, equality/signed compares, or general C ABI yet
+- no stack frame support, spills, calls, branches, signed compares, or general C ABI yet
 - the end-to-end harness currently accepts only relocation-free leaf functions from the supported subset
 - the Python image packer is a small test utility, not a general-purpose 8051 linker

--- a/overlay/llvm/lib/Target/MCS51/MCS51.h
+++ b/overlay/llvm/lib/Target/MCS51/MCS51.h
@@ -29,17 +29,18 @@ namespace MCS51ISD {
 enum NodeType : unsigned {
   FIRST_NUMBER = ISD::BUILTIN_OP_END,
   RET_FLAG,
-  UCMP
+  CMP
 };
 } // namespace MCS51ISD
 
-namespace MCS51UCmpFlags {
+namespace MCS51CmpFlags {
 enum Flags : uint8_t {
   None = 0,
   SwapOperands = 1u << 0,
   InvertResult = 1u << 1,
+  UseXorNonZero = 1u << 2,
 };
-} // namespace MCS51UCmpFlags
+} // namespace MCS51CmpFlags
 
 } // namespace llvm
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
@@ -36,7 +36,9 @@ public:
   static char ID;
 
 private:
-  static bool isGPR8(Register Reg) { return MCS51::GPR8RegClass.contains(Reg); }
+  static bool isGPRReg(Register Reg) {
+    return MCS51::GPR8RegClass.contains(Reg) || MCS51::GPR1RegClass.contains(Reg);
+  }
 
   static MCOperand lowerPseudoOperand(const MachineOperand &MO) {
     if (MO.isReg())
@@ -85,26 +87,37 @@ private:
     emitMoveAToReg(MI->getOperand(0).getReg());
   }
 
-  void emitUnsignedComparePseudo(const MachineInstr *MI) {
+  void emitComparePseudo(const MachineInstr *MI) {
     const uint8_t Flags = static_cast<uint8_t>(MI->getOperand(3).getImm());
     const MachineOperand &LHS = MI->getOperand(1);
     const MachineOperand &RHS = MI->getOperand(2);
-    const MachineOperand &First =
-        (Flags & MCS51UCmpFlags::SwapOperands) ? RHS : LHS;
-    const MachineOperand &Second =
-        (Flags & MCS51UCmpFlags::SwapOperands) ? LHS : RHS;
+    if (Flags & MCS51CmpFlags::UseXorNonZero) {
+      emitLoadA(LHS);
+      if (RHS.isReg())
+        emitMCInst(MCS51::XRLA_r, {lowerPseudoOperand(RHS)});
+      else if (RHS.isImm())
+        emitMCInst(MCS51::XRLA_i, {lowerPseudoOperand(RHS)});
+      else
+        report_fatal_error("Unsupported MCS51 equality comparison RHS");
+      emitMCInst(MCS51::ADDA_i, {MCOperand::createImm(0xFF)});
+    } else {
+      const MachineOperand &First =
+          (Flags & MCS51CmpFlags::SwapOperands) ? RHS : LHS;
+      const MachineOperand &Second =
+          (Flags & MCS51CmpFlags::SwapOperands) ? LHS : RHS;
 
-    emitLoadA(First);
-    emitMCInst(MCS51::CLR_C, {});
-    if (Second.isReg())
-      emitMCInst(MCS51::SUBBA_r, {lowerPseudoOperand(Second)});
-    else if (Second.isImm())
-      emitMCInst(MCS51::SUBBA_i, {lowerPseudoOperand(Second)});
-    else
-      report_fatal_error("Unsupported MCS51 comparison RHS");
+      emitLoadA(First);
+      emitMCInst(MCS51::CLR_C, {});
+      if (Second.isReg())
+        emitMCInst(MCS51::SUBBA_r, {lowerPseudoOperand(Second)});
+      else if (Second.isImm())
+        emitMCInst(MCS51::SUBBA_i, {lowerPseudoOperand(Second)});
+      else
+        report_fatal_error("Unsupported MCS51 comparison RHS");
+    }
     emitMCInst(MCS51::CLR_A, {});
     emitMCInst(MCS51::RLC_A, {});
-    if (Flags & MCS51UCmpFlags::InvertResult)
+    if (Flags & MCS51CmpFlags::InvertResult)
       emitMCInst(MCS51::XRLA_i, {MCOperand::createImm(1)});
     emitMoveAToReg(MI->getOperand(0).getReg());
   }
@@ -129,11 +142,11 @@ void MCS51AsmPrinter::emitInstruction(const MachineInstr *MI) {
       emitLoadA(Src);
       return;
     }
-    if (Src.getReg() == MCS51::A && isGPR8(Dst.getReg())) {
+    if (Src.getReg() == MCS51::A && isGPRReg(Dst.getReg())) {
       emitMoveAToReg(Dst.getReg());
       return;
     }
-    if (isGPR8(Dst.getReg()) && isGPR8(Src.getReg())) {
+    if (isGPRReg(Dst.getReg()) && isGPRReg(Src.getReg())) {
       emitLoadA(Src);
       emitMoveAToReg(Dst.getReg());
       return;
@@ -173,13 +186,13 @@ void MCS51AsmPrinter::emitInstruction(const MachineInstr *MI) {
       report_fatal_error("Unsupported MCS51 subtraction RHS");
     emitMoveAToReg(MI->getOperand(0).getReg());
     return;
-  case MCS51::UCMP8rr:
-  case MCS51::UCMP8ri:
-  case MCS51::UCMP8ir:
-  case MCS51::UCMP1rr:
-  case MCS51::UCMP1ri:
-  case MCS51::UCMP1ir:
-    emitUnsignedComparePseudo(MI);
+  case MCS51::CMP8rr:
+  case MCS51::CMP8ri:
+  case MCS51::CMP8ir:
+  case MCS51::CMP1rr:
+  case MCS51::CMP1ri:
+  case MCS51::CMP1ir:
+    emitComparePseudo(MI);
     return;
   }
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
@@ -88,16 +88,16 @@ void MCS51DAGToDAGISel::Select(SDNode *Node) {
     return;
   }
 
-  if (Node->getOpcode() == MCS51ISD::UCMP) {
+  if (Node->getOpcode() == MCS51ISD::CMP) {
     SDLoc DL(Node);
     SDValue LHS = Node->getOperand(0);
     SDValue RHS = Node->getOperand(1);
     SDValue Flags = Node->getOperand(2);
     EVT ResultVT = Node->getValueType(0);
     const bool IsBoolResult = ResultVT == MVT::i1;
-    const unsigned RROpc = IsBoolResult ? MCS51::UCMP1rr : MCS51::UCMP8rr;
-    const unsigned RIOpc = IsBoolResult ? MCS51::UCMP1ri : MCS51::UCMP8ri;
-    const unsigned IROpc = IsBoolResult ? MCS51::UCMP1ir : MCS51::UCMP8ir;
+    const unsigned RROpc = IsBoolResult ? MCS51::CMP1rr : MCS51::CMP8rr;
+    const unsigned RIOpc = IsBoolResult ? MCS51::CMP1ri : MCS51::CMP8ri;
+    const unsigned IROpc = IsBoolResult ? MCS51::CMP1ir : MCS51::CMP8ir;
 
     if (auto *RHSImm = dyn_cast<ConstantSDNode>(RHS)) {
       SDValue TargetImm =

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
@@ -20,26 +20,30 @@ using namespace llvm;
 
 namespace {
 
-uint8_t getUnsignedCompareFlags(ISD::CondCode CC) {
+uint8_t getCompareFlags(ISD::CondCode CC) {
   switch (CC) {
+  case ISD::SETEQ:
+    return MCS51CmpFlags::UseXorNonZero | MCS51CmpFlags::InvertResult;
+  case ISD::SETNE:
+    return MCS51CmpFlags::UseXorNonZero;
   case ISD::SETULT:
-    return MCS51UCmpFlags::None;
+    return MCS51CmpFlags::None;
   case ISD::SETUGE:
-    return MCS51UCmpFlags::InvertResult;
+    return MCS51CmpFlags::InvertResult;
   case ISD::SETUGT:
-    return MCS51UCmpFlags::SwapOperands;
+    return MCS51CmpFlags::SwapOperands;
   case ISD::SETULE:
-    return MCS51UCmpFlags::SwapOperands | MCS51UCmpFlags::InvertResult;
+    return MCS51CmpFlags::SwapOperands | MCS51CmpFlags::InvertResult;
   default:
     report_fatal_error(
-        "MCS51 MVP backend supports only unsigned i8 ordering comparisons");
+        "MCS51 MVP backend supports only i8 eq/ne and unsigned ordering comparisons");
   }
 }
 
-SDValue emitUnsignedCompareMaterialization(SelectionDAG &DAG, const SDLoc &DL,
-                                          EVT ResultVT, SDValue LHS,
-                                          SDValue RHS, uint8_t Flags) {
-  return DAG.getNode(MCS51ISD::UCMP, DL, ResultVT, LHS, RHS,
+SDValue emitCompareMaterialization(SelectionDAG &DAG, const SDLoc &DL,
+                                   EVT ResultVT, SDValue LHS, SDValue RHS,
+                                   uint8_t Flags) {
+  return DAG.getNode(MCS51ISD::CMP, DL, ResultVT, LHS, RHS,
                      DAG.getTargetConstant(Flags, DL, MVT::i8));
 }
 
@@ -105,11 +109,11 @@ SDValue MCS51TargetLowering::LowerSetCC(SDValue Op,
   if (Op.getOperand(0).getValueType() != MVT::i8 ||
       Op.getOperand(1).getValueType() != MVT::i8)
     report_fatal_error(
-        "MCS51 MVP backend supports only i8 ordering comparisons");
+        "MCS51 MVP backend supports only i8 eq/ne and unsigned ordering comparisons");
 
-  return emitUnsignedCompareMaterialization(
+  return emitCompareMaterialization(
       DAG, SDLoc(Op), Op.getValueType(), Op.getOperand(0), Op.getOperand(1),
-      getUnsignedCompareFlags(cast<CondCodeSDNode>(Op.getOperand(2))->get()));
+      getCompareFlags(cast<CondCodeSDNode>(Op.getOperand(2))->get()));
 }
 
 SDValue MCS51TargetLowering::LowerSelect(SDValue Op,
@@ -131,17 +135,16 @@ SDValue MCS51TargetLowering::LowerSelect(SDValue Op,
     report_fatal_error(
         "MCS51 MVP backend supports only selects driven by i8 setcc");
 
-  uint8_t Flags =
-      getUnsignedCompareFlags(cast<CondCodeSDNode>(SetCC.getOperand(2))->get());
+  uint8_t Flags = getCompareFlags(cast<CondCodeSDNode>(SetCC.getOperand(2))->get());
   if (TrueC->getZExtValue() == 0 && FalseC->getZExtValue() == 1)
-    Flags ^= MCS51UCmpFlags::InvertResult;
+    Flags ^= MCS51CmpFlags::InvertResult;
   else if (TrueC->getZExtValue() != 1 || FalseC->getZExtValue() != 0)
     report_fatal_error(
         "MCS51 MVP backend supports only select materialization to 0/1");
 
-  return emitUnsignedCompareMaterialization(DAG, SDLoc(Op), Op.getValueType(),
-                                            SetCC.getOperand(0),
-                                            SetCC.getOperand(1), Flags);
+  return emitCompareMaterialization(DAG, SDLoc(Op), Op.getValueType(),
+                                    SetCC.getOperand(0), SetCC.getOperand(1),
+                                    Flags);
 }
 
 SDValue MCS51TargetLowering::LowerSelectCC(SDValue Op,
@@ -157,17 +160,15 @@ SDValue MCS51TargetLowering::LowerSelectCC(SDValue Op,
     report_fatal_error(
         "MCS51 MVP backend supports only constant i8 select_cc results");
 
-  uint8_t Flags =
-      getUnsignedCompareFlags(cast<CondCodeSDNode>(Op.getOperand(4))->get());
+  uint8_t Flags = getCompareFlags(cast<CondCodeSDNode>(Op.getOperand(4))->get());
   if (TrueC->getZExtValue() == 0 && FalseC->getZExtValue() == 1)
-    Flags ^= MCS51UCmpFlags::InvertResult;
+    Flags ^= MCS51CmpFlags::InvertResult;
   else if (TrueC->getZExtValue() != 1 || FalseC->getZExtValue() != 0)
     report_fatal_error(
         "MCS51 MVP backend supports only select_cc materialization to 0/1");
 
-  return emitUnsignedCompareMaterialization(DAG, SDLoc(Op), Op.getValueType(),
-                                            Op.getOperand(0),
-                                            Op.getOperand(1), Flags);
+  return emitCompareMaterialization(DAG, SDLoc(Op), Op.getValueType(),
+                                    Op.getOperand(0), Op.getOperand(1), Flags);
 }
 
 SDValue MCS51TargetLowering::LowerZeroExtend(SDValue Op,
@@ -183,12 +184,12 @@ SDValue MCS51TargetLowering::LowerZeroExtend(SDValue Op,
   if (SetCC.getOperand(0).getValueType() != MVT::i8 ||
       SetCC.getOperand(1).getValueType() != MVT::i8)
     report_fatal_error(
-        "MCS51 MVP backend supports only i8 ordering comparisons");
+        "MCS51 MVP backend supports only i8 eq/ne and unsigned ordering comparisons");
 
-  return emitUnsignedCompareMaterialization(
+  return emitCompareMaterialization(
       DAG, SDLoc(Op), Op.getValueType(), SetCC.getOperand(0),
       SetCC.getOperand(1),
-      getUnsignedCompareFlags(cast<CondCodeSDNode>(SetCC.getOperand(2))->get()));
+      getCompareFlags(cast<CondCodeSDNode>(SetCC.getOperand(2))->get()));
 }
 
 bool MCS51TargetLowering::CanLowerReturn(

--- a/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
+++ b/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
@@ -57,18 +57,18 @@ def SUB8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
 def SUB8ri : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, i8imm:$rhs), "",
                          [(set GPR8:$dst, (sub GPR8:$lhs, imm:$rhs))]>;
 
-def UCMP8rr : MCS51Pseudo<(outs GPR8:$dst),
-                          (ins GPR8:$lhs, GPR8:$rhs, i8imm:$flags)>;
-def UCMP8ri : MCS51Pseudo<(outs GPR8:$dst),
-                          (ins GPR8:$lhs, i8imm:$rhs, i8imm:$flags)>;
-def UCMP8ir : MCS51Pseudo<(outs GPR8:$dst),
-                          (ins i8imm:$lhs, GPR8:$rhs, i8imm:$flags)>;
-def UCMP1rr : MCS51Pseudo<(outs GPR1:$dst),
-                          (ins GPR8:$lhs, GPR8:$rhs, i8imm:$flags)>;
-def UCMP1ri : MCS51Pseudo<(outs GPR1:$dst),
-                          (ins GPR8:$lhs, i8imm:$rhs, i8imm:$flags)>;
-def UCMP1ir : MCS51Pseudo<(outs GPR1:$dst),
-                          (ins i8imm:$lhs, GPR8:$rhs, i8imm:$flags)>;
+def CMP8rr : MCS51Pseudo<(outs GPR8:$dst),
+                         (ins GPR8:$lhs, GPR8:$rhs, i8imm:$flags)>;
+def CMP8ri : MCS51Pseudo<(outs GPR8:$dst),
+                         (ins GPR8:$lhs, i8imm:$rhs, i8imm:$flags)>;
+def CMP8ir : MCS51Pseudo<(outs GPR8:$dst),
+                         (ins i8imm:$lhs, GPR8:$rhs, i8imm:$flags)>;
+def CMP1rr : MCS51Pseudo<(outs GPR1:$dst),
+                         (ins GPR8:$lhs, GPR8:$rhs, i8imm:$flags)>;
+def CMP1ri : MCS51Pseudo<(outs GPR1:$dst),
+                         (ins GPR8:$lhs, i8imm:$rhs, i8imm:$flags)>;
+def CMP1ir : MCS51Pseudo<(outs GPR1:$dst),
+                         (ins i8imm:$lhs, GPR8:$rhs, i8imm:$flags)>;
 
 let Defs = [A], isAsCheapAsAMove = 1 in {
   def MOVA_r : MCS51Inst<"mov a, $src", (outs), (ins GPR8:$src)>;

--- a/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
@@ -153,3 +153,38 @@ entry:
 ; CHECK: mov r7, a
 ; CHECK: mov a, r7
 ; CHECK: ret
+
+define i8 @eq_u8(i8 %a, i8 %b) {
+entry:
+  %cmp = icmp eq i8 %a, %b
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: eq_u8:
+; CHECK: mov a, r7
+; CHECK: xrl a, r6
+; CHECK: add a, #255
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: xrl a, #1
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @ne_imm_u8(i8 %a) {
+entry:
+  %cmp = icmp ne i8 %a, 200
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: ne_imm_u8:
+; CHECK: mov a, r7
+; CHECK: xrl a, #-56
+; CHECK: add a, #255
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret

--- a/tests/e2e/cases.json
+++ b/tests/e2e/cases.json
@@ -68,5 +68,19 @@
     "function": "ule_u8",
     "args": [7, 200],
     "expected": 1
+  },
+  {
+    "name": "eq_u8",
+    "file": "eq_u8.c",
+    "function": "eq_u8",
+    "args": [200, 200],
+    "expected": 1
+  },
+  {
+    "name": "ne_imm_u8",
+    "file": "ne_imm_u8.c",
+    "function": "ne_imm_u8",
+    "args": [7],
+    "expected": 1
   }
 ]

--- a/tests/e2e/eq_u8.c
+++ b/tests/e2e/eq_u8.c
@@ -1,0 +1,3 @@
+unsigned char eq_u8(unsigned char a, unsigned char b) {
+  return a == b;
+}

--- a/tests/e2e/ne_imm_u8.c
+++ b/tests/e2e/ne_imm_u8.c
@@ -1,0 +1,3 @@
+unsigned char ne_imm_u8(unsigned char a) {
+  return a != 200;
+}


### PR DESCRIPTION
## Summary
- extend the compare materialization path to support `icmp eq/ne` in addition to unsigned ordering compares
- add LLVM regression coverage for register-register and immediate equality paths
- add end-to-end tests and update the documented supported subset

## Validation
- GitHub Actions `test` check
