### PR TITLE
Add low-byte i8 multiplication for MCS-51

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The backend currently supports a narrow but working subset:
 - up to two arguments passed in `R7` and `R6`
 - `i8` return values in `A`
 - `icmp eq/ne` and unsigned ordering comparisons lowered to `0/1` results
-- `add`, `sub`, `and`, `or`, `xor`, and integer constants
+- `add`, `sub`, `mul` (low byte), `and`, `or`, `xor`, and integer constants
 - `llc -filetype=obj` for the supported subset
 - end-to-end verification from `C` source to machine code executed in `ucsim_51`
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
@@ -166,6 +166,18 @@ void MCS51AsmPrinter::emitInstruction(const MachineInstr *MI) {
   case MCS51::AND8ri:
     emitBinaryPseudo(MI, MCS51::ANLA_r, MCS51::ANLA_i);
     return;
+  case MCS51::MUL8rr:
+  case MCS51::MUL8ri:
+    emitLoadA(MI->getOperand(1));
+    if (MI->getOperand(2).isReg())
+      emitMCInst(MCS51::MOVB_r, {lowerPseudoOperand(MI->getOperand(2))});
+    else if (MI->getOperand(2).isImm())
+      emitMCInst(MCS51::MOVB_i, {lowerPseudoOperand(MI->getOperand(2))});
+    else
+      report_fatal_error("Unsupported MCS51 multiplication RHS");
+    emitMCInst(MCS51::MUL_AB, {});
+    emitMoveAToReg(MI->getOperand(0).getReg());
+    return;
   case MCS51::OR8rr:
   case MCS51::OR8ri:
     emitBinaryPseudo(MI, MCS51::ORLA_r, MCS51::ORLA_i);

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
@@ -131,6 +131,10 @@ void MCS51DAGToDAGISel::Select(SDNode *Node) {
       if (selectBinaryI8(Node, MCS51::AND8rr, MCS51::AND8ri, true))
         return;
       break;
+    case ISD::MUL:
+      if (selectBinaryI8(Node, MCS51::MUL8rr, MCS51::MUL8ri, true))
+        return;
+      break;
     case ISD::OR:
       if (selectBinaryI8(Node, MCS51::OR8rr, MCS51::OR8ri, true))
         return;

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
@@ -71,6 +71,7 @@ MCS51TargetLowering::MCS51TargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::ADD, MVT::i8, Legal);
   setOperationAction(ISD::SUB, MVT::i8, Legal);
   setOperationAction(ISD::AND, MVT::i8, Legal);
+  setOperationAction(ISD::MUL, MVT::i8, Legal);
   setOperationAction(ISD::OR, MVT::i8, Legal);
   setOperationAction(ISD::XOR, MVT::i8, Legal);
   setOperationAction(ISD::SETCC, MVT::i8, Custom);

--- a/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
+++ b/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
@@ -50,6 +50,10 @@ let isCommutable = 1 in {
                            [(set GPR8:$dst, (xor GPR8:$lhs, GPR8:$rhs))]>;
   def XOR8ri : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, i8imm:$rhs), "",
                            [(set GPR8:$dst, (xor GPR8:$lhs, imm:$rhs))]>;
+  def MUL8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
+                           [(set GPR8:$dst, (mul GPR8:$lhs, GPR8:$rhs))]>;
+  def MUL8ri : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, i8imm:$rhs), "",
+                           [(set GPR8:$dst, (mul GPR8:$lhs, imm:$rhs))]>;
 }
 
 def SUB8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
@@ -78,8 +82,20 @@ let Defs = [A], isAsCheapAsAMove = 1 in {
   def CLR_A  : MCS51Inst<"clr a", (outs), (ins)>;
 }
 
+let Defs = [B], isAsCheapAsAMove = 1 in {
+  def MOVB_r : MCS51Inst<"mov b, $src", (outs), (ins GPR8:$src)> {
+    let Size = 2;
+  }
+  def MOVB_i : MCS51Inst<"mov b, $src", (outs), (ins i8imm:$src)> {
+    let Size = 3;
+  }
+}
+
 let Defs = [A, PSW], Uses = [A, PSW] in
   def RLC_A : MCS51Inst<"rlc a", (outs), (ins)>;
+
+let Defs = [A, B, PSW], Uses = [A, B] in
+  def MUL_AB : MCS51Inst<"mul ab", (outs), (ins)>;
 
 let Uses = [A], isAsCheapAsAMove = 1 in
   def MOVR_a : MCS51Inst<"mov $dst, a", (outs GPR8:$dst), (ins)>;

--- a/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
@@ -117,11 +117,23 @@ void MCS51MCCodeEmitter::encodeInstruction(const MCInst &MI,
     emitByte(CB, 0x74);
     emitByte(CB, getImm8(MI, 0));
     return;
+  case MCS51::MOVB_r:
+    emitByte(CB, static_cast<uint8_t>(0x88u + getRegNum(MI, 0)));
+    emitByte(CB, 0xF0);
+    return;
+  case MCS51::MOVB_i:
+    emitByte(CB, 0x75);
+    emitByte(CB, 0xF0);
+    emitByte(CB, getImm8(MI, 0));
+    return;
   case MCS51::CLR_A:
     emitByte(CB, 0xE4);
     return;
   case MCS51::RLC_A:
     emitByte(CB, 0x33);
+    return;
+  case MCS51::MUL_AB:
+    emitByte(CB, 0xA4);
     return;
   case MCS51::MOVR_a:
     emitByte(CB, static_cast<uint8_t>(0xF8u + getRegNum(MI, 0)));

--- a/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
@@ -50,6 +50,34 @@ entry:
 ; CHECK: mov a, r7
 ; CHECK: ret
 
+define i8 @mul_u8(i8 %a, i8 %b) {
+entry:
+  %prod = mul i8 %a, %b
+  ret i8 %prod
+}
+
+; CHECK-LABEL: mul_u8:
+; CHECK: mov a, r7
+; CHECK: mov b, r6
+; CHECK: mul ab
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @mul_imm_u8(i8 %a) {
+entry:
+  %prod = mul i8 %a, 13
+  ret i8 %prod
+}
+
+; CHECK-LABEL: mul_imm_u8:
+; CHECK: mov a, r7
+; CHECK: mov b, #13
+; CHECK: mul ab
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
 define i8 @ult_u8(i8 %a, i8 %b) {
 entry:
   %cmp = icmp ult i8 %a, %b

--- a/tests/e2e/cases.json
+++ b/tests/e2e/cases.json
@@ -21,6 +21,13 @@
     "expected": 102
   },
   {
+    "name": "mul_u8",
+    "file": "mul_u8.c",
+    "function": "mul_u8",
+    "args": [20, 13],
+    "expected": 4
+  },
+  {
     "name": "const_42",
     "file": "const_42.c",
     "function": "const_42",

--- a/tests/e2e/mul_u8.c
+++ b/tests/e2e/mul_u8.c
@@ -1,0 +1,3 @@
+unsigned char mul_u8(unsigned char a, unsigned char b) {
+  return a * b;
+}


### PR DESCRIPTION
## Summary
- add low-byte `i8` multiplication lowering using `mul ab`
- add codegen regression coverage for register and immediate forms
- add end-to-end runtime coverage on the MCS-51 emulator

## Validation
- GitHub Actions `test` check
