### PR TITLE
Add low-byte i8 unsigned division for MCS-51

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The backend currently supports a narrow but working subset:
 - up to two arguments passed in `R7` and `R6`
 - `i8` return values in `A`
 - `icmp eq/ne` and unsigned ordering comparisons lowered to `0/1` results
-- `add`, `sub`, `mul` (low byte), `and`, `or`, `xor`, and integer constants
+- `add`, `sub`, `mul` (low byte), `udiv`, `and`, `or`, `xor`, and integer constants
 - `llc -filetype=obj` for the supported subset
 - end-to-end verification from `C` source to machine code executed in `ucsim_51`
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
@@ -74,6 +74,18 @@ private:
     report_fatal_error("Unsupported MCS51 accumulator load source");
   }
 
+  void emitLoadB(const MachineOperand &Src) {
+    if (Src.isReg()) {
+      emitMCInst(MCS51::MOVB_r, {MCOperand::createReg(Src.getReg())});
+      return;
+    }
+    if (Src.isImm()) {
+      emitMCInst(MCS51::MOVB_i, {MCOperand::createImm(Src.getImm())});
+      return;
+    }
+    report_fatal_error("Unsupported MCS51 B register load source");
+  }
+
   void emitBinaryPseudo(const MachineInstr *MI, unsigned AccRegOpcode,
                         unsigned AccImmOpcode) {
     emitLoadA(MI->getOperand(1));
@@ -169,13 +181,14 @@ void MCS51AsmPrinter::emitInstruction(const MachineInstr *MI) {
   case MCS51::MUL8rr:
   case MCS51::MUL8ri:
     emitLoadA(MI->getOperand(1));
-    if (MI->getOperand(2).isReg())
-      emitMCInst(MCS51::MOVB_r, {lowerPseudoOperand(MI->getOperand(2))});
-    else if (MI->getOperand(2).isImm())
-      emitMCInst(MCS51::MOVB_i, {lowerPseudoOperand(MI->getOperand(2))});
-    else
-      report_fatal_error("Unsupported MCS51 multiplication RHS");
+    emitLoadB(MI->getOperand(2));
     emitMCInst(MCS51::MUL_AB, {});
+    emitMoveAToReg(MI->getOperand(0).getReg());
+    return;
+  case MCS51::DIV8rr:
+    emitLoadA(MI->getOperand(1));
+    emitLoadB(MI->getOperand(2));
+    emitMCInst(MCS51::DIV_AB, {});
     emitMoveAToReg(MI->getOperand(0).getReg());
     return;
   case MCS51::OR8rr:

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
@@ -135,6 +135,13 @@ void MCS51DAGToDAGISel::Select(SDNode *Node) {
       if (selectBinaryI8(Node, MCS51::MUL8rr, MCS51::MUL8ri, true))
         return;
       break;
+    case ISD::UDIV:
+      if (isa<ConstantSDNode>(Node->getOperand(1)))
+        break;
+      CurDAG->SelectNodeTo(Node, MCS51::DIV8rr, MVT::i8, Node->getOperand(0),
+                           Node->getOperand(1));
+      return;
+      break;
     case ISD::OR:
       if (selectBinaryI8(Node, MCS51::OR8rr, MCS51::OR8ri, true))
         return;

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
@@ -72,6 +72,7 @@ MCS51TargetLowering::MCS51TargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::SUB, MVT::i8, Legal);
   setOperationAction(ISD::AND, MVT::i8, Legal);
   setOperationAction(ISD::MUL, MVT::i8, Legal);
+  setOperationAction(ISD::UDIV, MVT::i8, Legal);
   setOperationAction(ISD::OR, MVT::i8, Legal);
   setOperationAction(ISD::XOR, MVT::i8, Legal);
   setOperationAction(ISD::SETCC, MVT::i8, Custom);

--- a/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
+++ b/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
@@ -60,6 +60,8 @@ def SUB8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
                          [(set GPR8:$dst, (sub GPR8:$lhs, GPR8:$rhs))]>;
 def SUB8ri : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, i8imm:$rhs), "",
                          [(set GPR8:$dst, (sub GPR8:$lhs, imm:$rhs))]>;
+def DIV8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
+                         [(set GPR8:$dst, (udiv GPR8:$lhs, GPR8:$rhs))]>;
 
 def CMP8rr : MCS51Pseudo<(outs GPR8:$dst),
                          (ins GPR8:$lhs, GPR8:$rhs, i8imm:$flags)>;
@@ -96,6 +98,9 @@ let Defs = [A, PSW], Uses = [A, PSW] in
 
 let Defs = [A, B, PSW], Uses = [A, B] in
   def MUL_AB : MCS51Inst<"mul ab", (outs), (ins)>;
+
+let Defs = [A, B, PSW], Uses = [A, B] in
+  def DIV_AB : MCS51Inst<"div ab", (outs), (ins)>;
 
 let Uses = [A], isAsCheapAsAMove = 1 in
   def MOVR_a : MCS51Inst<"mov $dst, a", (outs GPR8:$dst), (ins)>;

--- a/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
@@ -135,6 +135,9 @@ void MCS51MCCodeEmitter::encodeInstruction(const MCInst &MI,
   case MCS51::MUL_AB:
     emitByte(CB, 0xA4);
     return;
+  case MCS51::DIV_AB:
+    emitByte(CB, 0x84);
+    return;
   case MCS51::MOVR_a:
     emitByte(CB, static_cast<uint8_t>(0xF8u + getRegNum(MI, 0)));
     return;

--- a/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
@@ -78,6 +78,20 @@ entry:
 ; CHECK: mov a, r7
 ; CHECK: ret
 
+define i8 @udiv_u8(i8 %a, i8 %b) {
+entry:
+  %quot = udiv i8 %a, %b
+  ret i8 %quot
+}
+
+; CHECK-LABEL: udiv_u8:
+; CHECK: mov a, r7
+; CHECK: mov b, r6
+; CHECK: div ab
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
 define i8 @ult_u8(i8 %a, i8 %b) {
 entry:
   %cmp = icmp ult i8 %a, %b

--- a/tests/e2e/cases.json
+++ b/tests/e2e/cases.json
@@ -28,6 +28,13 @@
     "expected": 4
   },
   {
+    "name": "udiv_u8",
+    "file": "udiv_u8.c",
+    "function": "udiv_u8",
+    "args": [250, 13],
+    "expected": 19
+  },
+  {
     "name": "const_42",
     "file": "const_42.c",
     "function": "const_42",

--- a/tests/e2e/udiv_u8.c
+++ b/tests/e2e/udiv_u8.c
@@ -1,0 +1,1 @@
+unsigned char udiv_u8(unsigned char a, unsigned char b) { return a / b; }


### PR DESCRIPTION
## Summary
- add low-byte unsigned `i8` division lowering using `div ab`
- add codegen regression coverage for the register-register form
- add end-to-end runtime coverage in the MCS-51 emulator

## Validation
- GitHub Actions `test` check
