### PR TITLE
Add low-byte i8 unsigned remainder for MCS-51

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The backend currently supports a narrow but working subset:
 - up to two arguments passed in `R7` and `R6`
 - `i8` return values in `A`
 - `icmp eq/ne` and unsigned ordering comparisons lowered to `0/1` results
-- `add`, `sub`, `mul` (low byte), `udiv`, `and`, `or`, `xor`, and integer constants
+- `add`, `sub`, `mul` (low byte), `udiv`, `urem`, `and`, `or`, `xor`, and integer constants
 - `llc -filetype=obj` for the supported subset
 - end-to-end verification from `C` source to machine code executed in `ucsim_51`
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
@@ -60,6 +60,10 @@ private:
     emitMCInst(MCS51::MOVR_a, {MCOperand::createReg(Dst)});
   }
 
+  void emitMoveBToReg(Register Dst) {
+    emitMCInst(MCS51::MOVR_b, {MCOperand::createReg(Dst)});
+  }
+
   void emitLoadA(const MachineOperand &Src) {
     if (Src.isReg()) {
       if (Src.getReg() == MCS51::A)
@@ -190,6 +194,12 @@ void MCS51AsmPrinter::emitInstruction(const MachineInstr *MI) {
     emitLoadB(MI->getOperand(2));
     emitMCInst(MCS51::DIV_AB, {});
     emitMoveAToReg(MI->getOperand(0).getReg());
+    return;
+  case MCS51::REM8rr:
+    emitLoadA(MI->getOperand(1));
+    emitLoadB(MI->getOperand(2));
+    emitMCInst(MCS51::DIV_AB, {});
+    emitMoveBToReg(MI->getOperand(0).getReg());
     return;
   case MCS51::OR8rr:
   case MCS51::OR8ri:

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
@@ -141,7 +141,12 @@ void MCS51DAGToDAGISel::Select(SDNode *Node) {
       CurDAG->SelectNodeTo(Node, MCS51::DIV8rr, MVT::i8, Node->getOperand(0),
                            Node->getOperand(1));
       return;
-      break;
+    case ISD::UREM:
+      if (isa<ConstantSDNode>(Node->getOperand(1)))
+        break;
+      CurDAG->SelectNodeTo(Node, MCS51::REM8rr, MVT::i8, Node->getOperand(0),
+                           Node->getOperand(1));
+      return;
     case ISD::OR:
       if (selectBinaryI8(Node, MCS51::OR8rr, MCS51::OR8ri, true))
         return;

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
@@ -73,6 +73,7 @@ MCS51TargetLowering::MCS51TargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::AND, MVT::i8, Legal);
   setOperationAction(ISD::MUL, MVT::i8, Legal);
   setOperationAction(ISD::UDIV, MVT::i8, Legal);
+  setOperationAction(ISD::UREM, MVT::i8, Legal);
   setOperationAction(ISD::OR, MVT::i8, Legal);
   setOperationAction(ISD::XOR, MVT::i8, Legal);
   setOperationAction(ISD::SETCC, MVT::i8, Custom);

--- a/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
+++ b/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
@@ -62,6 +62,8 @@ def SUB8ri : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, i8imm:$rhs), "",
                          [(set GPR8:$dst, (sub GPR8:$lhs, imm:$rhs))]>;
 def DIV8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
                          [(set GPR8:$dst, (udiv GPR8:$lhs, GPR8:$rhs))]>;
+def REM8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
+                         [(set GPR8:$dst, (urem GPR8:$lhs, GPR8:$rhs))]>;
 
 def CMP8rr : MCS51Pseudo<(outs GPR8:$dst),
                          (ins GPR8:$lhs, GPR8:$rhs, i8imm:$flags)>;
@@ -104,6 +106,11 @@ let Defs = [A, B, PSW], Uses = [A, B] in
 
 let Uses = [A], isAsCheapAsAMove = 1 in
   def MOVR_a : MCS51Inst<"mov $dst, a", (outs GPR8:$dst), (ins)>;
+
+let Uses = [B], isAsCheapAsAMove = 1 in
+  def MOVR_b : MCS51Inst<"mov $dst, b", (outs GPR8:$dst), (ins)> {
+    let Size = 2;
+  }
 
 let Defs = [A], Uses = [A] in {
   def ADDA_r : MCS51Inst<"add a, $src", (outs), (ins GPR8:$src)>;

--- a/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
@@ -141,6 +141,10 @@ void MCS51MCCodeEmitter::encodeInstruction(const MCInst &MI,
   case MCS51::MOVR_a:
     emitByte(CB, static_cast<uint8_t>(0xF8u + getRegNum(MI, 0)));
     return;
+  case MCS51::MOVR_b:
+    emitByte(CB, static_cast<uint8_t>(0xA8u + getRegNum(MI, 0)));
+    emitByte(CB, 0xF0);
+    return;
   case MCS51::ADDA_r:
     emitByte(CB, static_cast<uint8_t>(0x28u + getRegNum(MI, 0)));
     return;

--- a/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
@@ -92,6 +92,20 @@ entry:
 ; CHECK: mov a, r7
 ; CHECK: ret
 
+define i8 @urem_u8(i8 %a, i8 %b) {
+entry:
+  %rem = urem i8 %a, %b
+  ret i8 %rem
+}
+
+; CHECK-LABEL: urem_u8:
+; CHECK: mov a, r7
+; CHECK: mov b, r6
+; CHECK: div ab
+; CHECK: mov r7, b
+; CHECK: mov a, r7
+; CHECK: ret
+
 define i8 @ult_u8(i8 %a, i8 %b) {
 entry:
   %cmp = icmp ult i8 %a, %b

--- a/tests/e2e/cases.json
+++ b/tests/e2e/cases.json
@@ -35,6 +35,13 @@
     "expected": 19
   },
   {
+    "name": "urem_u8",
+    "file": "urem_u8.c",
+    "function": "urem_u8",
+    "args": [250, 13],
+    "expected": 3
+  },
+  {
     "name": "const_42",
     "file": "const_42.c",
     "function": "const_42",

--- a/tests/e2e/urem_u8.c
+++ b/tests/e2e/urem_u8.c
@@ -1,0 +1,1 @@
+unsigned char urem_u8(unsigned char a, unsigned char b) { return a % b; }


### PR DESCRIPTION
## Summary
- add low-byte unsigned `i8` remainder lowering using `div ab`
- move the remainder from `B` back into a general-purpose register
- add codegen regression coverage and end-to-end emulator coverage

## Validation
- GitHub Actions `test` check
