### PR TITLE
Add constant-count i8 left shift for MCS-51

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The backend currently supports a narrow but working subset:
 - up to two arguments passed in `R7` and `R6`
 - `i8` return values in `A`
 - `icmp eq/ne` and unsigned ordering comparisons lowered to `0/1` results
-- `add`, `sub`, `mul` (low byte), `udiv`, `urem`, `and`, `or`, `xor`, and integer constants
+- `add`, `sub`, constant-count `shl`, `mul` (low byte), `udiv`, `urem`, `and`, `or`, `xor`, and integer constants
 - `llc -filetype=obj` for the supported subset
 - end-to-end verification from `C` source to machine code executed in `ucsim_51`
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
@@ -182,6 +182,18 @@ void MCS51AsmPrinter::emitInstruction(const MachineInstr *MI) {
   case MCS51::AND8ri:
     emitBinaryPseudo(MI, MCS51::ANLA_r, MCS51::ANLA_i);
     return;
+  case MCS51::SHL8ri: {
+    emitLoadA(MI->getOperand(1));
+    const int64_t ShiftCount = MI->getOperand(2).getImm();
+    if (ShiftCount < 0 || ShiftCount > 7)
+      report_fatal_error("MCS51 supports only constant i8 shifts in the range 0..7");
+    for (int64_t I = 0; I < ShiftCount; ++I) {
+      emitMCInst(MCS51::CLR_C, {});
+      emitMCInst(MCS51::RLC_A, {});
+    }
+    emitMoveAToReg(MI->getOperand(0).getReg());
+    return;
+  }
   case MCS51::MUL8rr:
   case MCS51::MUL8ri:
     emitLoadA(MI->getOperand(1));

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
@@ -131,6 +131,16 @@ void MCS51DAGToDAGISel::Select(SDNode *Node) {
       if (selectBinaryI8(Node, MCS51::AND8rr, MCS51::AND8ri, true))
         return;
       break;
+    case ISD::SHL:
+      if (auto *ShiftAmt = dyn_cast<ConstantSDNode>(Node->getOperand(1))) {
+        SDLoc DL(Node);
+        SDValue TargetImm =
+            CurDAG->getTargetConstant(ShiftAmt->getSExtValue(), DL, MVT::i8);
+        CurDAG->SelectNodeTo(Node, MCS51::SHL8ri, MVT::i8,
+                             Node->getOperand(0), TargetImm);
+        return;
+      }
+      break;
     case ISD::MUL:
       if (selectBinaryI8(Node, MCS51::MUL8rr, MCS51::MUL8ri, true))
         return;

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
@@ -71,6 +71,7 @@ MCS51TargetLowering::MCS51TargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::ADD, MVT::i8, Legal);
   setOperationAction(ISD::SUB, MVT::i8, Legal);
   setOperationAction(ISD::AND, MVT::i8, Legal);
+  setOperationAction(ISD::SHL, MVT::i8, Legal);
   setOperationAction(ISD::MUL, MVT::i8, Legal);
   setOperationAction(ISD::UDIV, MVT::i8, Legal);
   setOperationAction(ISD::UREM, MVT::i8, Legal);

--- a/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
+++ b/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
@@ -60,6 +60,7 @@ def SUB8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
                          [(set GPR8:$dst, (sub GPR8:$lhs, GPR8:$rhs))]>;
 def SUB8ri : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, i8imm:$rhs), "",
                          [(set GPR8:$dst, (sub GPR8:$lhs, imm:$rhs))]>;
+def SHL8ri : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, i8imm:$rhs), "">;
 def DIV8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
                          [(set GPR8:$dst, (udiv GPR8:$lhs, GPR8:$rhs))]>;
 def REM8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",

--- a/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
@@ -37,6 +37,38 @@ entry:
 ; CHECK: mov a, r7
 ; CHECK: ret
 
+define i8 @shl1_u8(i8 %a) {
+entry:
+  %res = shl i8 %a, 1
+  ret i8 %res
+}
+
+; CHECK-LABEL: shl1_u8:
+; CHECK: mov a, r7
+; CHECK: clr c
+; CHECK: rlc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @shl3_u8(i8 %a) {
+entry:
+  %res = shl i8 %a, 3
+  ret i8 %res
+}
+
+; CHECK-LABEL: shl3_u8:
+; CHECK: mov a, r7
+; CHECK: clr c
+; CHECK: rlc a
+; CHECK: clr c
+; CHECK: rlc a
+; CHECK: clr c
+; CHECK: rlc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
 define i8 @xor_imm(i8 %a) {
 entry:
   %x = xor i8 %a, 90

--- a/tests/e2e/cases.json
+++ b/tests/e2e/cases.json
@@ -14,6 +14,27 @@
     "expected": 22
   },
   {
+    "name": "shl1_u8_basic",
+    "file": "shl1_u8.c",
+    "function": "shl1_u8",
+    "args": [73],
+    "expected": 146
+  },
+  {
+    "name": "shl1_u8_trunc",
+    "file": "shl1_u8.c",
+    "function": "shl1_u8",
+    "args": [225],
+    "expected": 194
+  },
+  {
+    "name": "shl3_u8",
+    "file": "shl3_u8.c",
+    "function": "shl3_u8",
+    "args": [19],
+    "expected": 152
+  },
+  {
     "name": "xor_imm",
     "file": "xor_imm.c",
     "function": "xor_imm",

--- a/tests/e2e/shl1_u8.c
+++ b/tests/e2e/shl1_u8.c
@@ -1,0 +1,1 @@
+unsigned char shl1_u8(unsigned char a) { return a << 1; }

--- a/tests/e2e/shl3_u8.c
+++ b/tests/e2e/shl3_u8.c
@@ -1,0 +1,1 @@
+unsigned char shl3_u8(unsigned char a) { return a << 3; }


### PR DESCRIPTION
## Summary
- add constant-count `i8` left shift lowering for the MCS-51 backend
- lower shifts through repeated `clr c` / `rlc a` sequences
- expand runtime coverage with multiple left-shift cases, including truncating behavior

## Validation
- GitHub Actions `test` check
