### PR TITLE
[codex] Add constant-count i8 logical right shift

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The backend currently supports a narrow but working subset:
 - up to two arguments passed in `R7` and `R6`
 - `i8` return values in `A`
 - `icmp eq/ne` and unsigned ordering comparisons lowered to `0/1` results
-- `add`, `sub`, constant-count `shl`, `mul` (low byte), `udiv`, `urem`, `and`, `or`, `xor`, and integer constants
+- `add`, `sub`, constant-count `shl` and `lshr`, `mul` (low byte), `udiv`, `urem`, `and`, `or`, `xor`, and integer constants
 - `llc -filetype=obj` for the supported subset
 - end-to-end verification from `C` source to machine code executed in `ucsim_51`
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51.h
+++ b/overlay/llvm/lib/Target/MCS51/MCS51.h
@@ -30,7 +30,8 @@ enum NodeType : unsigned {
   FIRST_NUMBER = ISD::BUILTIN_OP_END,
   RET_FLAG,
   CMP,
-  SHL
+  SHL,
+  LSHR
 };
 } // namespace MCS51ISD
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
@@ -195,6 +195,18 @@ void MCS51AsmPrinter::emitInstruction(const MachineInstr *MI) {
     emitMoveAToReg(MI->getOperand(0).getReg());
     return;
   }
+  case MCS51::LSHR8ri: {
+    emitLoadA(MI->getOperand(1));
+    const int64_t ShiftCount = MI->getOperand(2).getImm();
+    if (ShiftCount < 0 || ShiftCount > 7)
+      report_fatal_error("MCS51 supports only constant i8 shifts in the range 0..7");
+    for (int64_t I = 0; I < ShiftCount; ++I) {
+      emitMCInst(MCS51::CLR_C, {});
+      emitMCInst(MCS51::RRC_A, {});
+    }
+    emitMoveAToReg(MI->getOperand(0).getReg());
+    return;
+  }
   case MCS51::MUL8rr:
   case MCS51::MUL8ri:
     emitLoadA(MI->getOperand(1));

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
@@ -123,6 +123,12 @@ void MCS51DAGToDAGISel::Select(SDNode *Node) {
     return;
   }
 
+  if (Node->getOpcode() == MCS51ISD::LSHR) {
+    CurDAG->SelectNodeTo(Node, MCS51::LSHR8ri, MVT::i8, Node->getOperand(0),
+                         Node->getOperand(1));
+    return;
+  }
+
   if (Node->getSimpleValueType(0) == MVT::i8) {
     switch (Node->getOpcode()) {
     case ISD::ADD:

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
@@ -72,6 +72,7 @@ MCS51TargetLowering::MCS51TargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::SUB, MVT::i8, Legal);
   setOperationAction(ISD::AND, MVT::i8, Legal);
   setOperationAction(ISD::SHL, MVT::i8, Custom);
+  setOperationAction(ISD::SRL, MVT::i8, Custom);
   setOperationAction(ISD::MUL, MVT::i8, Legal);
   setOperationAction(ISD::UDIV, MVT::i8, Legal);
   setOperationAction(ISD::UREM, MVT::i8, Legal);
@@ -97,6 +98,8 @@ SDValue MCS51TargetLowering::LowerOperation(SDValue Op,
   switch (Op.getOpcode()) {
   case ISD::SHL:
     return LowerShiftLeft(Op, DAG);
+  case ISD::SRL:
+    return LowerLogicalShiftRight(Op, DAG);
   case ISD::SETCC:
     return LowerSetCC(Op, DAG);
   case ISD::SELECT:
@@ -128,6 +131,27 @@ SDValue MCS51TargetLowering::LowerShiftLeft(SDValue Op,
 
   SDLoc DL(Op);
   return DAG.getNode(MCS51ISD::SHL, DL, Op.getValueType(), Op.getOperand(0),
+                     DAG.getTargetConstant(ShiftCount, DL, MVT::i8));
+}
+
+SDValue MCS51TargetLowering::LowerLogicalShiftRight(
+    SDValue Op, SelectionDAG &DAG) const {
+  if (Op.getValueType() != MVT::i8 || Op.getOperand(0).getValueType() != MVT::i8)
+    report_fatal_error(
+        "MCS51 MVP backend supports only constant-count i8 logical right shifts");
+
+  const auto *ShiftAmt = dyn_cast<ConstantSDNode>(Op.getOperand(1));
+  if (ShiftAmt == nullptr)
+    report_fatal_error(
+        "MCS51 MVP backend supports only constant-count i8 logical right shifts");
+
+  const int64_t ShiftCount = ShiftAmt->getSExtValue();
+  if (ShiftCount < 0 || ShiftCount > 7)
+    report_fatal_error(
+        "MCS51 MVP backend supports only constant-count i8 logical right shifts in the range 0..7");
+
+  SDLoc DL(Op);
+  return DAG.getNode(MCS51ISD::LSHR, DL, Op.getValueType(), Op.getOperand(0),
                      DAG.getTargetConstant(ShiftCount, DL, MVT::i8));
 }
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.h
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.h
@@ -42,6 +42,7 @@ public:
 
 private:
   SDValue LowerShiftLeft(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerLogicalShiftRight(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSetCC(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSelect(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSelectCC(SDValue Op, SelectionDAG &DAG) const;

--- a/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
+++ b/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
@@ -61,6 +61,7 @@ def SUB8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
 def SUB8ri : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, i8imm:$rhs), "",
                          [(set GPR8:$dst, (sub GPR8:$lhs, imm:$rhs))]>;
 def SHL8ri : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, i8imm:$rhs), "">;
+def LSHR8ri : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, i8imm:$rhs), "">;
 def DIV8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
                          [(set GPR8:$dst, (udiv GPR8:$lhs, GPR8:$rhs))]>;
 def REM8rr : MCS51Pseudo<(outs GPR8:$dst), (ins GPR8:$lhs, GPR8:$rhs), "",
@@ -98,6 +99,9 @@ let Defs = [B], isAsCheapAsAMove = 1 in {
 
 let Defs = [A, PSW], Uses = [A, PSW] in
   def RLC_A : MCS51Inst<"rlc a", (outs), (ins)>;
+
+let Defs = [A, PSW], Uses = [A, PSW] in
+  def RRC_A : MCS51Inst<"rrc a", (outs), (ins)>;
 
 let Defs = [A, B, PSW], Uses = [A, B] in
   def MUL_AB : MCS51Inst<"mul ab", (outs), (ins)>;

--- a/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
@@ -132,6 +132,9 @@ void MCS51MCCodeEmitter::encodeInstruction(const MCInst &MI,
   case MCS51::RLC_A:
     emitByte(CB, 0x33);
     return;
+  case MCS51::RRC_A:
+    emitByte(CB, 0x13);
+    return;
   case MCS51::MUL_AB:
     emitByte(CB, 0xA4);
     return;

--- a/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
@@ -69,6 +69,38 @@ entry:
 ; CHECK: mov a, r7
 ; CHECK: ret
 
+define i8 @lshr1_u8(i8 %a) {
+entry:
+  %res = lshr i8 %a, 1
+  ret i8 %res
+}
+
+; CHECK-LABEL: lshr1_u8:
+; CHECK: mov a, r7
+; CHECK: clr c
+; CHECK: rrc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @lshr3_u8(i8 %a) {
+entry:
+  %res = lshr i8 %a, 3
+  ret i8 %res
+}
+
+; CHECK-LABEL: lshr3_u8:
+; CHECK: mov a, r7
+; CHECK: clr c
+; CHECK: rrc a
+; CHECK: clr c
+; CHECK: rrc a
+; CHECK: clr c
+; CHECK: rrc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
 define i8 @xor_imm(i8 %a) {
 entry:
   %x = xor i8 %a, 90

--- a/tests/e2e/cases.json
+++ b/tests/e2e/cases.json
@@ -35,6 +35,27 @@
     "expected": 152
   },
   {
+    "name": "lshr1_u8_basic",
+    "file": "lshr1_u8.c",
+    "function": "lshr1_u8",
+    "args": [146],
+    "expected": 73
+  },
+  {
+    "name": "lshr1_u8_zero_fill",
+    "file": "lshr1_u8.c",
+    "function": "lshr1_u8",
+    "args": [225],
+    "expected": 112
+  },
+  {
+    "name": "lshr3_u8",
+    "file": "lshr3_u8.c",
+    "function": "lshr3_u8",
+    "args": [225],
+    "expected": 28
+  },
+  {
     "name": "xor_imm",
     "file": "xor_imm.c",
     "function": "xor_imm",

--- a/tests/e2e/lshr1_u8.c
+++ b/tests/e2e/lshr1_u8.c
@@ -1,0 +1,1 @@
+unsigned char lshr1_u8(unsigned char a) { return a >> 1; }

--- a/tests/e2e/lshr3_u8.c
+++ b/tests/e2e/lshr3_u8.c
@@ -1,0 +1,1 @@
+unsigned char lshr3_u8(unsigned char a) { return a >> 3; }


### PR DESCRIPTION
## Summary
- add constant-count `lshr i8` selection for the MCS51 backend
- emit repeated `clr c` + `rrc a` sequences for zero-fill right shifts
- add LLVM regression coverage, end-to-end cases, and README scope updates

## Why
Issue #22 calls for constant-count logical right shift support in the current `i8` leaf-function subset.

## Validation
- `make build`
- `./out/llvm-build/bin/llc -march=mcs51 -mtriple=mcs51-unknown-elf -verify-machineinstrs -filetype=asm -o ./out/llvm-build/basic-i8.s ./overlay/llvm/test/CodeGen/MCS51/basic-i8.ll`
- `./out/llvm-build/bin/FileCheck ./overlay/llvm/test/CodeGen/MCS51/basic-i8.ll < ./out/llvm-build/basic-i8.s`
- local e2e harness currently blocked on missing `ucsim_51`/`s51` on this host; Docker/CI validation to follow

Closes #22