### PR TITLE
[codex] Fix i8 shl legalization contract

### DIFF
--- a/overlay/llvm/lib/Target/MCS51/MCS51.h
+++ b/overlay/llvm/lib/Target/MCS51/MCS51.h
@@ -29,7 +29,8 @@ namespace MCS51ISD {
 enum NodeType : unsigned {
   FIRST_NUMBER = ISD::BUILTIN_OP_END,
   RET_FLAG,
-  CMP
+  CMP,
+  SHL
 };
 } // namespace MCS51ISD
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
@@ -186,7 +186,8 @@ void MCS51AsmPrinter::emitInstruction(const MachineInstr *MI) {
     emitLoadA(MI->getOperand(1));
     const int64_t ShiftCount = MI->getOperand(2).getImm();
     if (ShiftCount < 0 || ShiftCount > 7)
-      report_fatal_error("MCS51 supports only constant i8 shifts in the range 0..7");
+      report_fatal_error(
+          "MCS51 MVP backend supports only constant-count i8 left shifts in the range 0..7");
     for (int64_t I = 0; I < ShiftCount; ++I) {
       emitMCInst(MCS51::CLR_C, {});
       emitMCInst(MCS51::RLC_A, {});

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
@@ -117,6 +117,12 @@ void MCS51DAGToDAGISel::Select(SDNode *Node) {
     return;
   }
 
+  if (Node->getOpcode() == MCS51ISD::SHL) {
+    CurDAG->SelectNodeTo(Node, MCS51::SHL8ri, MVT::i8, Node->getOperand(0),
+                         Node->getOperand(1));
+    return;
+  }
+
   if (Node->getSimpleValueType(0) == MVT::i8) {
     switch (Node->getOpcode()) {
     case ISD::ADD:
@@ -130,16 +136,6 @@ void MCS51DAGToDAGISel::Select(SDNode *Node) {
     case ISD::AND:
       if (selectBinaryI8(Node, MCS51::AND8rr, MCS51::AND8ri, true))
         return;
-      break;
-    case ISD::SHL:
-      if (auto *ShiftAmt = dyn_cast<ConstantSDNode>(Node->getOperand(1))) {
-        SDLoc DL(Node);
-        SDValue TargetImm =
-            CurDAG->getTargetConstant(ShiftAmt->getSExtValue(), DL, MVT::i8);
-        CurDAG->SelectNodeTo(Node, MCS51::SHL8ri, MVT::i8,
-                             Node->getOperand(0), TargetImm);
-        return;
-      }
       break;
     case ISD::MUL:
       if (selectBinaryI8(Node, MCS51::MUL8rr, MCS51::MUL8ri, true))

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
@@ -71,7 +71,7 @@ MCS51TargetLowering::MCS51TargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::ADD, MVT::i8, Legal);
   setOperationAction(ISD::SUB, MVT::i8, Legal);
   setOperationAction(ISD::AND, MVT::i8, Legal);
-  setOperationAction(ISD::SHL, MVT::i8, Legal);
+  setOperationAction(ISD::SHL, MVT::i8, Custom);
   setOperationAction(ISD::MUL, MVT::i8, Legal);
   setOperationAction(ISD::UDIV, MVT::i8, Legal);
   setOperationAction(ISD::UREM, MVT::i8, Legal);
@@ -95,6 +95,8 @@ EVT MCS51TargetLowering::getSetCCResultType(const DataLayout &DL,
 SDValue MCS51TargetLowering::LowerOperation(SDValue Op,
                                             SelectionDAG &DAG) const {
   switch (Op.getOpcode()) {
+  case ISD::SHL:
+    return LowerShiftLeft(Op, DAG);
   case ISD::SETCC:
     return LowerSetCC(Op, DAG);
   case ISD::SELECT:
@@ -106,6 +108,27 @@ SDValue MCS51TargetLowering::LowerOperation(SDValue Op,
   default:
     llvm_unreachable("unimplemented operand");
   }
+}
+
+SDValue MCS51TargetLowering::LowerShiftLeft(SDValue Op,
+                                            SelectionDAG &DAG) const {
+  if (Op.getValueType() != MVT::i8 || Op.getOperand(0).getValueType() != MVT::i8)
+    report_fatal_error(
+        "MCS51 MVP backend supports only constant-count i8 left shifts");
+
+  const auto *ShiftAmt = dyn_cast<ConstantSDNode>(Op.getOperand(1));
+  if (ShiftAmt == nullptr)
+    report_fatal_error(
+        "MCS51 MVP backend supports only constant-count i8 left shifts");
+
+  const int64_t ShiftCount = ShiftAmt->getSExtValue();
+  if (ShiftCount < 0 || ShiftCount > 7)
+    report_fatal_error(
+        "MCS51 MVP backend supports only constant-count i8 left shifts in the range 0..7");
+
+  SDLoc DL(Op);
+  return DAG.getNode(MCS51ISD::SHL, DL, Op.getValueType(), Op.getOperand(0),
+                     DAG.getTargetConstant(ShiftCount, DL, MVT::i8));
 }
 
 SDValue MCS51TargetLowering::LowerSetCC(SDValue Op,

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.h
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.h
@@ -41,6 +41,7 @@ public:
                       const SDLoc &DL, SelectionDAG &DAG) const override;
 
 private:
+  SDValue LowerShiftLeft(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSetCC(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSelect(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSelectCC(SDValue Op, SelectionDAG &DAG) const;

--- a/overlay/llvm/test/CodeGen/MCS51/unsupported-shl.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/unsupported-shl.ll
@@ -1,0 +1,9 @@
+; RUN: not --crash llc -march=mcs51 -mtriple=mcs51-unknown-elf -verify-machineinstrs -filetype=asm -o /dev/null < %s 2>&1 | FileCheck %s
+
+define i8 @shl_var_u8(i8 %a, i8 %amt) {
+entry:
+  %res = shl i8 %a, %amt
+  ret i8 %res
+}
+
+; CHECK: LLVM ERROR: MCS51 MVP backend supports only constant-count i8 left shifts

--- a/scripts/bootstrap_llvm.py
+++ b/scripts/bootstrap_llvm.py
@@ -48,9 +48,9 @@ def bootstrap() -> Path:
     backend_dst = src_dir / "llvm" / "lib" / "Target" / "MCS51"
     copy_overlay_tree(backend_src, backend_dst)
 
-    codegen_test_src = overlay_root() / "llvm" / "test" / "CodeGen" / "MCS51" / "basic-i8.ll"
-    codegen_test_dst = src_dir / "llvm" / "test" / "CodeGen" / "MCS51" / "basic-i8.ll"
-    copy_overlay_file(codegen_test_src, codegen_test_dst)
+    codegen_test_src = overlay_root() / "llvm" / "test" / "CodeGen" / "MCS51"
+    codegen_test_dst = src_dir / "llvm" / "test" / "CodeGen" / "MCS51"
+    copy_overlay_tree(codegen_test_src, codegen_test_dst)
 
     return src_dir
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 from dataclasses import dataclass
 
 from scripts.bootstrap_llvm import bootstrap
@@ -39,7 +40,9 @@ def run_codegen_tests() -> None:
     build_dir = llvm_build_dir()
     llc = build_dir / "bin" / "llc"
     filecheck = build_dir / "bin" / "FileCheck"
-    test_file = src_dir / "llvm" / "test" / "CodeGen" / "MCS51" / "basic-i8.ll"
+    test_dir = src_dir / "llvm" / "test" / "CodeGen" / "MCS51"
+    supported_test = test_dir / "basic-i8.ll"
+    unsupported_shift_test = test_dir / "unsupported-shl.ll"
     asm_file = build_dir / "basic-i8.s"
     obj_file = build_dir / "basic-i8.o"
 
@@ -57,10 +60,10 @@ def run_codegen_tests() -> None:
             "-filetype=asm",
             "-o",
             str(asm_file),
-            str(test_file),
+            str(supported_test),
         ]
     )
-    run([str(filecheck), str(test_file)], input_text=asm_file.read_text())
+    run([str(filecheck), str(supported_test)], input_text=asm_file.read_text())
     run(
         [
             str(llc),
@@ -70,11 +73,29 @@ def run_codegen_tests() -> None:
             "-filetype=obj",
             "-o",
             str(obj_file),
-            str(test_file),
+            str(supported_test),
         ]
     )
     if obj_file.stat().st_size == 0:
         raise SystemExit(f"Empty object file produced by llc: {obj_file}")
+
+    unsupported = subprocess.run(
+        [
+            str(llc),
+            "-march=mcs51",
+            "-mtriple=mcs51-unknown-elf",
+            "-verify-machineinstrs",
+            "-filetype=asm",
+            "-o",
+            str(build_dir / "unsupported-shl.s"),
+            str(unsupported_shift_test),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    if unsupported.returncode == 0:
+        raise SystemExit("Expected unsupported-shl.ll to fail during llc")
+    run([str(filecheck), str(unsupported_shift_test)], input_text=unsupported.stderr)
 
 
 def run_e2e_case(case: E2ECase) -> None:


### PR DESCRIPTION
## Summary
- stop advertising `ISD::SHL` as generally legal for `i8` and custom-lower only constant-count left shifts
- route supported constant shifts through an explicit MCS51 DAG node and keep the backend diagnostic specific for unsupported variable counts
- add unsupported-path regression coverage and teach the repo test harness to exercise it

## Why
Issue #8 pointed out that non-constant `shl i8` fell through to a generic selection failure even though the backend only supports constant-count left shifts.

## Validation
- targeted `llc` + `FileCheck` on `basic-i8.ll`
- targeted negative `llc` + `FileCheck` on `unsupported-shl.ll`
- `make test` (codegen portion passed; local e2e blocked by missing host emulator `ucsim_51`/`s51`)
- `make docker-test` (running separately while PR is opened)
