### PR TITLE
[codex] support constant i8 divisors in udiv/urem lowering

### DIFF
--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
@@ -90,7 +90,7 @@ bool MCS51DAGToDAGISel::selectDivRemI8(SDNode *Node, unsigned RegOpc) {
 
   if (auto *C = dyn_cast<ConstantSDNode>(Divisor)) {
     SDValue TargetImm =
-        CurDAG->getTargetConstant(C->getSExtValue(), DL, MVT::i8);
+        CurDAG->getTargetConstant(C->getZExtValue() & 0xFF, DL, MVT::i8);
     SDNode *MoveImm = CurDAG->getMachineNode(MCS51::MOV8ri, DL, MVT::i8, TargetImm);
     Divisor = SDValue(MoveImm, 0);
   }

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelDAGToDAG.cpp
@@ -32,6 +32,7 @@ public:
 private:
   bool selectBinaryI8(SDNode *Node, unsigned RegOpc, unsigned ImmOpc,
                       bool IsCommutable);
+  bool selectDivRemI8(SDNode *Node, unsigned RegOpc);
   void SelectCode(SDNode *Node);
 };
 
@@ -79,6 +80,22 @@ bool MCS51DAGToDAGISel::selectBinaryI8(SDNode *Node, unsigned RegOpc,
       return selectImm(RHS, C);
 
   CurDAG->SelectNodeTo(Node, RegOpc, MVT::i8, LHS, RHS);
+  return true;
+}
+
+bool MCS51DAGToDAGISel::selectDivRemI8(SDNode *Node, unsigned RegOpc) {
+  SDLoc DL(Node);
+  SDValue Dividend = Node->getOperand(0);
+  SDValue Divisor = Node->getOperand(1);
+
+  if (auto *C = dyn_cast<ConstantSDNode>(Divisor)) {
+    SDValue TargetImm =
+        CurDAG->getTargetConstant(C->getSExtValue(), DL, MVT::i8);
+    SDNode *MoveImm = CurDAG->getMachineNode(MCS51::MOV8ri, DL, MVT::i8, TargetImm);
+    Divisor = SDValue(MoveImm, 0);
+  }
+
+  CurDAG->SelectNodeTo(Node, RegOpc, MVT::i8, Dividend, Divisor);
   return true;
 }
 
@@ -148,17 +165,13 @@ void MCS51DAGToDAGISel::Select(SDNode *Node) {
         return;
       break;
     case ISD::UDIV:
-      if (isa<ConstantSDNode>(Node->getOperand(1)))
-        break;
-      CurDAG->SelectNodeTo(Node, MCS51::DIV8rr, MVT::i8, Node->getOperand(0),
-                           Node->getOperand(1));
-      return;
+      if (selectDivRemI8(Node, MCS51::DIV8rr))
+        return;
+      break;
     case ISD::UREM:
-      if (isa<ConstantSDNode>(Node->getOperand(1)))
-        break;
-      CurDAG->SelectNodeTo(Node, MCS51::REM8rr, MVT::i8, Node->getOperand(0),
-                           Node->getOperand(1));
-      return;
+      if (selectDivRemI8(Node, MCS51::REM8rr))
+        return;
+      break;
     case ISD::OR:
       if (selectBinaryI8(Node, MCS51::OR8rr, MCS51::OR8ri, true))
         return;

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
@@ -93,6 +93,11 @@ EVT MCS51TargetLowering::getSetCCResultType(const DataLayout &DL,
   return MVT::i1;
 }
 
+bool MCS51TargetLowering::isIntDivCheap(EVT VT, AttributeList Attr) const {
+  (void)Attr;
+  return VT == MVT::i8;
+}
+
 SDValue MCS51TargetLowering::LowerOperation(SDValue Op,
                                             SelectionDAG &DAG) const {
   switch (Op.getOpcode()) {

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.h
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.h
@@ -22,6 +22,8 @@ public:
   EVT getSetCCResultType(const DataLayout &DL, LLVMContext &Context,
                          EVT VT) const override;
 
+  bool isIntDivCheap(EVT VT, AttributeList Attr) const override;
+
   SDValue LowerOperation(SDValue Op, SelectionDAG &DAG) const override;
 
   bool CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,

--- a/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51InstPrinter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51InstPrinter.cpp
@@ -36,7 +36,7 @@ void MCS51InstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
   if (Op.isReg()) {
     O << getRegisterName(Op.getReg());
   } else if (Op.isImm()) {
-    O << '#' << Op.getImm();
+    O << '#' << (static_cast<uint64_t>(Op.getImm()) & 0xFF);
   } else if (Op.isExpr()) {
     MAI.printExpr(O, *Op.getExpr());
   } else {

--- a/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
@@ -185,6 +185,21 @@ entry:
 ; CHECK: mov a, r7
 ; CHECK: ret
 
+define i8 @udiv_imm_highbit_u8(i8 %a) {
+entry:
+  %quot = udiv i8 %a, 200
+  ret i8 %quot
+}
+
+; CHECK-LABEL: udiv_imm_highbit_u8:
+; CHECK: mov [[HIGHDIV:r[0-6]]], #200
+; CHECK: mov a, r7
+; CHECK: mov b, [[HIGHDIV]]
+; CHECK: div ab
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
 define i8 @urem_imm_u8(i8 %a) {
 entry:
   %rem = urem i8 %a, 13
@@ -331,7 +346,7 @@ entry:
 
 ; CHECK-LABEL: ne_imm_u8:
 ; CHECK: mov a, r7
-; CHECK: xrl a, #-56
+; CHECK: xrl a, #200
 ; CHECK: add a, #255
 ; CHECK: clr a
 ; CHECK: rlc a

--- a/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
@@ -170,6 +170,36 @@ entry:
 ; CHECK: mov a, r7
 ; CHECK: ret
 
+define i8 @udiv_imm_u8(i8 %a) {
+entry:
+  %quot = udiv i8 %a, 13
+  ret i8 %quot
+}
+
+; CHECK-LABEL: udiv_imm_u8:
+; CHECK: mov [[DIVREG:r[0-6]]], #13
+; CHECK: mov a, r7
+; CHECK: mov b, [[DIVREG]]
+; CHECK: div ab
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @urem_imm_u8(i8 %a) {
+entry:
+  %rem = urem i8 %a, 13
+  ret i8 %rem
+}
+
+; CHECK-LABEL: urem_imm_u8:
+; CHECK: mov [[REMREG:r[0-6]]], #13
+; CHECK: mov a, r7
+; CHECK: mov b, [[REMREG]]
+; CHECK: div ab
+; CHECK: mov r7, b
+; CHECK: mov a, r7
+; CHECK: ret
+
 define i8 @ult_u8(i8 %a, i8 %b) {
 entry:
   %cmp = icmp ult i8 %a, %b

--- a/tests/e2e/cases.json
+++ b/tests/e2e/cases.json
@@ -84,6 +84,20 @@
     "expected": 3
   },
   {
+    "name": "udiv_imm_u8",
+    "file": "udiv_imm_u8.c",
+    "function": "udiv_imm_u8",
+    "args": [250],
+    "expected": 19
+  },
+  {
+    "name": "urem_imm_u8",
+    "file": "urem_imm_u8.c",
+    "function": "urem_imm_u8",
+    "args": [250],
+    "expected": 3
+  },
+  {
     "name": "const_42",
     "file": "const_42.c",
     "function": "const_42",

--- a/tests/e2e/udiv_imm_u8.c
+++ b/tests/e2e/udiv_imm_u8.c
@@ -1,0 +1,1 @@
+unsigned char udiv_imm_u8(unsigned char a) { return a / 13; }

--- a/tests/e2e/urem_imm_u8.c
+++ b/tests/e2e/urem_imm_u8.c
@@ -1,0 +1,1 @@
+unsigned char urem_imm_u8(unsigned char a) { return a % 13; }


### PR DESCRIPTION
## Summary
- treat `i8` integer division as cheap for MCS51 so SelectionDAG keeps constant-divisor `udiv`/`urem` nodes instead of rewriting them into unsupported magic-number sequences
- materialize constant divisors into a GPR during MCS51 DAG selection and reuse the existing `DIV8rr` / `REM8rr` lowering path
- add LLVM codegen coverage plus e2e cases for `udiv i8 %x, 13` and `urem i8 %x, 13`

## Why
Issue #7 reported that constant divisors in `i8 udiv/urem` could fail or miscompile before reaching the backend's `div ab` lowering path.

## Validation
- `llc -march=mcs51 -mtriple=mcs51-unknown-elf -verify-machineinstrs -filetype=asm overlay/llvm/test/CodeGen/MCS51/basic-i8.ll`
- `FileCheck overlay/llvm/test/CodeGen/MCS51/basic-i8.ll < out/llvm-build/basic-i8.s`
- `make docker-test` (started, but Docker killed the in-container LLVM rebuild with exit 137 before tests completed)
- local emulator e2e could not run on the host because `ucsim_51` / `s51` is not installed; CI should cover the new e2e cases
