### PR TITLE
Make unsupported-shl lit regression portable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ When a feature changes the supported subset, update all relevant surfaces togeth
 - Default workflow is one feature/fix per branch and one PR per branch.
 - Keep PRs narrow and traceable.
 - Do not merge without green CI.
+- If you encounter a real bug, tooling gap, or validation blocker while working, create a GitHub issue for it so the problem is tracked even if the current branch moves on.
 - If a PR implements a tracked GitHub issue, include an explicit closing keyword in the PR body such as `Closes #N`, `Fixes #N`, or `Resolves #N`.
 - After requesting Copilot review, do not merge only on the basis of green CI.
 - Copilot comments can arrive after checks pass, and in some cases even after a merge becomes available.

--- a/overlay/llvm/test/CodeGen/MCS51/unsupported-shl.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/unsupported-shl.ll
@@ -1,4 +1,4 @@
-; RUN: not --crash llc -march=mcs51 -mtriple=mcs51-unknown-elf -verify-machineinstrs -filetype=asm -o /dev/null < %s 2>&1 | FileCheck %s
+; RUN: not --crash llc -march=mcs51 -mtriple=mcs51-unknown-elf -verify-machineinstrs -filetype=asm -o %t < %s 2>&1 | FileCheck %s
 
 define i8 @shl_var_u8(i8 %a, i8 %amt) {
 entry:


### PR DESCRIPTION
## Summary
- switch `unsupported-shl.ll` from `/dev/null` to the lit-managed `%t` output path
- update agent guidance to require filing issues for bugs and validation blockers discovered during development
- record the local `llvm-lit` infrastructure gap as follow-up issue #28

## Validation
- direct `llc` failure path for `unsupported-shl.ll` still matches the expected diagnostic via `FileCheck`
- GitHub Actions `test` check

Closes #26
Related to #28
