### PR TITLE
Add signed i8 compare support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,9 @@ When a feature changes the supported subset, update all relevant surfaces togeth
 - codegen regression tests
 - end-to-end tests
 - `README.md` scope/limitations if user-visible support changed
+- `AGENTS.md` if recurring repo workflow guidance or contributor expectations changed
+
+Keep `AGENTS.md` and `README.md` current, but keep them concise. Add durable, high-signal guidance only; do not accumulate low-value reminders or transient worklog detail.
 
 ## Workflow Expectations
 
@@ -46,7 +49,10 @@ When a feature changes the supported subset, update all relevant surfaces togeth
 - Copilot comments can arrive after checks pass, and in some cases even after a merge becomes available.
 - Before merging, confirm that the Copilot review was actually submitted and inspect thread-level review comments, not just the review summary.
 - If Copilot was requested, wait for the review to land or explicitly time out after a reasonable polling window before merging.
+- Treat unresolved review threads as merge blockers until they are fixed or tracked in GitHub issues and explicitly resolved.
+- Before merging a PR that requested Copilot review, run `python3 -m scripts.check_review_threads --repo <owner/name> --pr <number> --require-copilot` and require it to pass.
 - If a review comment points out a real functional gap, either fix it or track it in GitHub issues.
+- If you run target-side checks directly against `out/llvm-build`, sync `overlay` into `out/llvm-src` first via `python3 -m scripts.bootstrap_llvm`.
 
 ## Current Roadmap
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ The backend currently supports a narrow but working subset:
 - leaf functions operating on `i8`
 - up to two arguments passed in `R7` and `R6`
 - `i8` return values in `A`
-- `icmp eq/ne` and unsigned ordering comparisons lowered to `0/1` results
+- `icmp eq/ne` plus signed and unsigned ordering comparisons lowered to `0/1` results
 - `add`, `sub`, constant-count `shl` and `lshr`, `mul` (low byte), `udiv`, `urem`, `and`, `or`, `xor`, and integer constants
 - `llc -filetype=obj` for the supported subset
 - end-to-end verification from `C` source to machine code executed in `ucsim_51`
 
 ## Limitations
 
-- no stack frame support, spills, calls, branches, signed compares, or general C ABI yet
+- no stack frame support, spills, calls, branches, or general C ABI yet
 - the end-to-end harness currently accepts only relocation-free leaf functions from the supported subset
 - the Python image packer is a small test utility, not a general-purpose 8051 linker

--- a/overlay/llvm/lib/Target/MCS51/MCS51.h
+++ b/overlay/llvm/lib/Target/MCS51/MCS51.h
@@ -41,6 +41,8 @@ enum Flags : uint8_t {
   SwapOperands = 1u << 0,
   InvertResult = 1u << 1,
   UseXorNonZero = 1u << 2,
+  BiasLHS = 1u << 3,
+  BiasRHS = 1u << 4,
 };
 } // namespace MCS51CmpFlags
 

--- a/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51AsmPrinter.cpp
@@ -64,6 +64,14 @@ private:
     emitMCInst(MCS51::MOVR_b, {MCOperand::createReg(Dst)});
   }
 
+  void emitMoveAToB() { emitMCInst(MCS51::MOVB_a, {}); }
+
+  static uint8_t getImm8Value(const MachineOperand &MO) {
+    if (!MO.isImm())
+      report_fatal_error("Unsupported non-immediate MCS51 operand");
+    return static_cast<uint8_t>(MO.getImm());
+  }
+
   void emitLoadA(const MachineOperand &Src) {
     if (Src.isReg()) {
       if (Src.getReg() == MCS51::A)
@@ -103,6 +111,12 @@ private:
     emitMoveAToReg(MI->getOperand(0).getReg());
   }
 
+  void emitLoadAWithBias(const MachineOperand &Src, bool Bias) {
+    emitLoadA(Src);
+    if (Bias)
+      emitMCInst(MCS51::XRLA_i, {MCOperand::createImm(0x80)});
+  }
+
   void emitComparePseudo(const MachineInstr *MI) {
     const uint8_t Flags = static_cast<uint8_t>(MI->getOperand(3).getImm());
     const MachineOperand &LHS = MI->getOperand(1);
@@ -121,15 +135,33 @@ private:
           (Flags & MCS51CmpFlags::SwapOperands) ? RHS : LHS;
       const MachineOperand &Second =
           (Flags & MCS51CmpFlags::SwapOperands) ? LHS : RHS;
+      const bool BiasFirst = (Flags & MCS51CmpFlags::SwapOperands)
+                                 ? (Flags & MCS51CmpFlags::BiasRHS)
+                                 : (Flags & MCS51CmpFlags::BiasLHS);
+      const bool BiasSecond = (Flags & MCS51CmpFlags::SwapOperands)
+                                  ? (Flags & MCS51CmpFlags::BiasLHS)
+                                  : (Flags & MCS51CmpFlags::BiasRHS);
 
-      emitLoadA(First);
-      emitMCInst(MCS51::CLR_C, {});
-      if (Second.isReg())
-        emitMCInst(MCS51::SUBBA_r, {lowerPseudoOperand(Second)});
-      else if (Second.isImm())
-        emitMCInst(MCS51::SUBBA_i, {lowerPseudoOperand(Second)});
-      else
-        report_fatal_error("Unsupported MCS51 comparison RHS");
+      if (Second.isReg() && BiasSecond) {
+        emitLoadAWithBias(Second, true);
+        emitMoveAToB();
+        emitLoadAWithBias(First, BiasFirst);
+        emitMCInst(MCS51::CLR_C, {});
+        emitMCInst(MCS51::SUBBA_b, {});
+      } else {
+        emitLoadAWithBias(First, BiasFirst);
+        emitMCInst(MCS51::CLR_C, {});
+        if (Second.isReg()) {
+          emitMCInst(MCS51::SUBBA_r, {lowerPseudoOperand(Second)});
+        } else if (Second.isImm()) {
+          uint8_t Imm = getImm8Value(Second);
+          if (BiasSecond)
+            Imm ^= 0x80;
+          emitMCInst(MCS51::SUBBA_i, {MCOperand::createImm(Imm)});
+        } else {
+          report_fatal_error("Unsupported MCS51 comparison RHS");
+        }
+      }
     }
     emitMCInst(MCS51::CLR_A, {});
     emitMCInst(MCS51::RLC_A, {});

--- a/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCS51ISelLowering.cpp
@@ -34,9 +34,20 @@ uint8_t getCompareFlags(ISD::CondCode CC) {
     return MCS51CmpFlags::SwapOperands;
   case ISD::SETULE:
     return MCS51CmpFlags::SwapOperands | MCS51CmpFlags::InvertResult;
+  case ISD::SETLT:
+    return MCS51CmpFlags::BiasLHS | MCS51CmpFlags::BiasRHS;
+  case ISD::SETGE:
+    return MCS51CmpFlags::BiasLHS | MCS51CmpFlags::BiasRHS |
+           MCS51CmpFlags::InvertResult;
+  case ISD::SETGT:
+    return MCS51CmpFlags::BiasLHS | MCS51CmpFlags::BiasRHS |
+           MCS51CmpFlags::SwapOperands;
+  case ISD::SETLE:
+    return MCS51CmpFlags::BiasLHS | MCS51CmpFlags::BiasRHS |
+           MCS51CmpFlags::SwapOperands | MCS51CmpFlags::InvertResult;
   default:
     report_fatal_error(
-        "MCS51 MVP backend supports only i8 eq/ne and unsigned ordering comparisons");
+        "MCS51 MVP backend supports only i8 eq/ne and signed/unsigned ordering comparisons");
   }
 }
 
@@ -165,7 +176,7 @@ SDValue MCS51TargetLowering::LowerSetCC(SDValue Op,
   if (Op.getOperand(0).getValueType() != MVT::i8 ||
       Op.getOperand(1).getValueType() != MVT::i8)
     report_fatal_error(
-        "MCS51 MVP backend supports only i8 eq/ne and unsigned ordering comparisons");
+        "MCS51 MVP backend supports only i8 eq/ne and signed/unsigned ordering comparisons");
 
   return emitCompareMaterialization(
       DAG, SDLoc(Op), Op.getValueType(), Op.getOperand(0), Op.getOperand(1),
@@ -240,7 +251,7 @@ SDValue MCS51TargetLowering::LowerZeroExtend(SDValue Op,
   if (SetCC.getOperand(0).getValueType() != MVT::i8 ||
       SetCC.getOperand(1).getValueType() != MVT::i8)
     report_fatal_error(
-        "MCS51 MVP backend supports only i8 eq/ne and unsigned ordering comparisons");
+        "MCS51 MVP backend supports only i8 eq/ne and signed/unsigned ordering comparisons");
 
   return emitCompareMaterialization(
       DAG, SDLoc(Op), Op.getValueType(), SetCC.getOperand(0),

--- a/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
+++ b/overlay/llvm/lib/Target/MCS51/MCS51InstrInfo.td
@@ -89,6 +89,9 @@ let Defs = [A], isAsCheapAsAMove = 1 in {
 }
 
 let Defs = [B], isAsCheapAsAMove = 1 in {
+  def MOVB_a : MCS51Inst<"mov b, a", (outs), (ins)> {
+    let Size = 2;
+  }
   def MOVB_r : MCS51Inst<"mov b, $src", (outs), (ins GPR8:$src)> {
     let Size = 2;
   }
@@ -140,6 +143,9 @@ let Defs = [PSW] in
   def CLR_C : MCS51Inst<"clr c", (outs), (ins)>;
 
 let Defs = [A, PSW], Uses = [A, PSW] in {
+  def SUBBA_b : MCS51Inst<"subb a, b", (outs), (ins)> {
+    let Size = 2;
+  }
   def SUBBA_r : MCS51Inst<"subb a, $src", (outs), (ins GPR8:$src)>;
   def SUBBA_i : MCS51Inst<"subb a, $src", (outs), (ins i8imm:$src)> {
     let Size = 2;

--- a/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
+++ b/overlay/llvm/lib/Target/MCS51/MCTargetDesc/MCS51MCCodeEmitter.cpp
@@ -121,6 +121,10 @@ void MCS51MCCodeEmitter::encodeInstruction(const MCInst &MI,
     emitByte(CB, static_cast<uint8_t>(0x88u + getRegNum(MI, 0)));
     emitByte(CB, 0xF0);
     return;
+  case MCS51::MOVB_a:
+    emitByte(CB, 0xF5);
+    emitByte(CB, 0xF0);
+    return;
   case MCS51::MOVB_i:
     emitByte(CB, 0x75);
     emitByte(CB, 0xF0);
@@ -181,6 +185,10 @@ void MCS51MCCodeEmitter::encodeInstruction(const MCInst &MI,
     return;
   case MCS51::SUBBA_r:
     emitByte(CB, static_cast<uint8_t>(0x98u + getRegNum(MI, 0)));
+    return;
+  case MCS51::SUBBA_b:
+    emitByte(CB, 0x95);
+    emitByte(CB, 0xF0);
     return;
   case MCS51::SUBBA_i:
     emitByte(CB, 0x94);

--- a/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
+++ b/overlay/llvm/test/CodeGen/MCS51/basic-i8.ll
@@ -353,3 +353,84 @@ entry:
 ; CHECK: mov r7, a
 ; CHECK: mov a, r7
 ; CHECK: ret
+
+define i8 @slt_i8(i8 %a, i8 %b) {
+entry:
+  %cmp = icmp slt i8 %a, %b
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: slt_i8:
+; CHECK: mov a, r6
+; CHECK: xrl a, #128
+; CHECK: mov b, a
+; CHECK: mov a, r7
+; CHECK: xrl a, #128
+; CHECK: clr c
+; CHECK: subb a, b
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @sgt_i8(i8 %a, i8 %b) {
+entry:
+  %cmp = icmp sgt i8 %a, %b
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: sgt_i8:
+; CHECK: mov a, r7
+; CHECK: xrl a, #128
+; CHECK: mov b, a
+; CHECK: mov a, r6
+; CHECK: xrl a, #128
+; CHECK: clr c
+; CHECK: subb a, b
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @sge_imm_i8(i8 %a) {
+entry:
+  %cmp = icmp sge i8 %a, -5
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: sge_imm_i8:
+; CHECK: mov a, r7
+; CHECK: xrl a, #128
+; CHECK: mov b, a
+; CHECK: mov a, #250
+; CHECK: xrl a, #128
+; CHECK: clr c
+; CHECK: subb a, b
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret
+
+define i8 @sle_imm_i8(i8 %a) {
+entry:
+  %cmp = icmp sle i8 %a, -5
+  %res = zext i1 %cmp to i8
+  ret i8 %res
+}
+
+; CHECK-LABEL: sle_imm_i8:
+; CHECK: mov a, r7
+; CHECK: xrl a, #128
+; CHECK: clr c
+; CHECK: subb a, #124
+; CHECK: clr a
+; CHECK: rlc a
+; CHECK: mov r7, a
+; CHECK: mov a, r7
+; CHECK: ret

--- a/scripts/check_review_threads.py
+++ b/scripts/check_review_threads.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+
+from scripts.common import ensure_tool
+
+
+COPILOT_LOGIN = "copilot-pull-request-reviewer"
+
+QUERY = """
+query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      number
+      title
+      url
+      reviews(first:100) {
+        nodes {
+          author { login }
+          state
+          submittedAt
+        }
+      }
+      reviewThreads(first:100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first:20) {
+            nodes {
+              author { login }
+              body
+              url
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@dataclass
+class ReviewThread:
+    path: str | None
+    line: int | None
+    body: str
+    url: str
+    author: str | None
+    is_resolved: bool
+    is_outdated: bool
+
+
+def fetch_pr(repo: str, number: int) -> dict:
+    ensure_tool("gh")
+    owner, name = repo.split("/", 1)
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-F",
+            f"number={number}",
+            "-f",
+            f"query={QUERY}",
+        ],
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)["data"]["repository"]["pullRequest"]
+
+
+def get_threads(pr: dict) -> list[ReviewThread]:
+    threads: list[ReviewThread] = []
+    for node in pr["reviewThreads"]["nodes"]:
+        comments = node["comments"]["nodes"]
+        last = comments[-1] if comments else None
+        threads.append(
+            ReviewThread(
+                path=node["path"],
+                line=node["line"],
+                body=(last["body"] if last else "").strip(),
+                url=(last["url"] if last else pr["url"]),
+                author=(last["author"]["login"] if last and last["author"] else None),
+                is_resolved=node["isResolved"],
+                is_outdated=node["isOutdated"],
+            )
+        )
+    return threads
+
+
+def has_copilot_feedback(pr: dict) -> bool:
+    for review in pr["reviews"]["nodes"]:
+        author = review["author"]
+        if author and author["login"] == COPILOT_LOGIN:
+            return True
+
+    for thread in get_threads(pr):
+        if thread.author == COPILOT_LOGIN:
+            return True
+
+    return False
+
+
+def print_unresolved_threads(threads: list[ReviewThread]) -> None:
+    if not threads:
+        return
+
+    print("Unresolved review threads:")
+    for thread in threads:
+        location = f"{thread.path}:{thread.line}" if thread.path else "<unknown>"
+        stale = " outdated" if thread.is_outdated else ""
+        author = thread.author or "unknown"
+        summary = thread.body.splitlines()[0] if thread.body else "<no body>"
+        print(f"- {location}{stale} by {author}: {summary}")
+        print(f"  {thread.url}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fail if a PR still has unresolved review threads."
+    )
+    parser.add_argument("--repo", required=True, help="GitHub repo in owner/name form")
+    parser.add_argument("--pr", type=int, required=True, help="Pull request number")
+    parser.add_argument(
+        "--require-copilot",
+        action="store_true",
+        help="Wait for Copilot review feedback before succeeding",
+    )
+    parser.add_argument(
+        "--wait-seconds",
+        type=int,
+        default=180,
+        help="How long to wait for Copilot feedback when --require-copilot is set",
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=int,
+        default=15,
+        help="Polling interval used while waiting for Copilot feedback",
+    )
+    args = parser.parse_args()
+
+    deadline = time.time() + max(args.wait_seconds, 0)
+    saw_copilot = False
+
+    while True:
+        pr = fetch_pr(args.repo, args.pr)
+        saw_copilot = saw_copilot or has_copilot_feedback(pr)
+        unresolved = [thread for thread in get_threads(pr) if not thread.is_resolved]
+
+        if args.require_copilot and not saw_copilot and time.time() < deadline:
+            remaining = int(max(deadline - time.time(), 0))
+            print(
+                f"Waiting for Copilot review on PR #{args.pr} "
+                f"({remaining}s remaining)..."
+            )
+            time.sleep(max(args.poll_seconds, 1))
+            continue
+
+        if args.require_copilot and not saw_copilot:
+            raise SystemExit(
+                f"Copilot review did not appear for PR #{args.pr} within "
+                f"{args.wait_seconds}s"
+            )
+
+        if unresolved:
+            print_unresolved_threads(unresolved)
+            raise SystemExit(
+                f"PR #{args.pr} still has {len(unresolved)} unresolved review thread(s)"
+            )
+
+        print(f"PR #{args.pr} is clear: no unresolved review threads remain.")
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/cases.json
+++ b/tests/e2e/cases.json
@@ -159,5 +159,33 @@
     "function": "ne_imm_u8",
     "args": [7],
     "expected": 1
+  },
+  {
+    "name": "slt_i8",
+    "file": "slt_i8.c",
+    "function": "slt_i8",
+    "args": [255, 1],
+    "expected": 1
+  },
+  {
+    "name": "sgt_i8",
+    "file": "sgt_i8.c",
+    "function": "sgt_i8",
+    "args": [1, 255],
+    "expected": 1
+  },
+  {
+    "name": "sge_imm_i8",
+    "file": "sge_imm_i8.c",
+    "function": "sge_imm_i8",
+    "args": [3],
+    "expected": 1
+  },
+  {
+    "name": "sle_imm_i8",
+    "file": "sle_imm_i8.c",
+    "function": "sle_imm_i8",
+    "args": [3],
+    "expected": 0
   }
 ]

--- a/tests/e2e/sge_imm_i8.c
+++ b/tests/e2e/sge_imm_i8.c
@@ -1,0 +1,1 @@
+unsigned char sge_imm_i8(signed char a) { return a >= -5; }

--- a/tests/e2e/sgt_i8.c
+++ b/tests/e2e/sgt_i8.c
@@ -1,0 +1,1 @@
+unsigned char sgt_i8(signed char a, signed char b) { return a > b; }

--- a/tests/e2e/sle_imm_i8.c
+++ b/tests/e2e/sle_imm_i8.c
@@ -1,0 +1,1 @@
+unsigned char sle_imm_i8(signed char a) { return a <= -5; }

--- a/tests/e2e/slt_i8.c
+++ b/tests/e2e/slt_i8.c
@@ -1,0 +1,1 @@
+unsigned char slt_i8(signed char a, signed char b) { return a < b; }


### PR DESCRIPTION
Summary:
- add signed `i8` ordering compares by biasing both operands with `xor 0x80` before reuse of the unsigned compare path
- extend codegen and e2e coverage with `slt`, `sgt`, and immediate-form signed comparisons
- add a small review-thread gate helper and document the merge check in `AGENTS.md`

Validation:
- `make test`

Closes #9
Related: #34